### PR TITLE
chore: correct compile from source ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Table of parameters
 Nitro server is compatible with the OpenAI format, so you can expect the same output as the OpenAI ChatGPT API.
 
 ## Compile from source
-To compile nitro please visit [Compile from source](docs/new/build-source.md)
+To compile nitro please visit [Compile from source](docs/docs/new/build-source.md)
 
 ## Download
 


### PR DESCRIPTION
## Describe Your Changes
- Correct compile from source ref, its 404 now.
<img width="986" alt="Screenshot 2024-01-11 at 22 45 26" src="https://github.com/janhq/nitro/assets/133622055/3fbadb1e-5017-4e0d-9490-8e987897a2ba">
