### PR TITLE
fix: engine init is broken

### DIFF
--- a/cortex-js/src/usecases/engines/engines.usecase.ts
+++ b/cortex-js/src/usecases/engines/engines.usecase.ts
@@ -101,7 +101,7 @@ export class EnginesUsecases {
               ? '-mac'
               : '-linux',
           // CPU Instructions - CPU | GPU Non-Vulkan
-          !isVulkan
+          !isVulkan && engine === Engines.llamaCPP
             ? `-noavx`
             : '',
           // Cuda


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where cortex looks for a wrong binary name to download. The engines got different release names. E.g. noavx on llama.cpp but not for others. Platform for both llama.cpp and tensorrt-llm but not onnx.

## Fixes Issues

- #1020
- #1021

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed