### PR TITLE
fix: handle stop server

### DIFF
--- a/engine/commands/run_cmd.cc
+++ b/engine/commands/run_cmd.cc
@@ -70,7 +70,6 @@ bool RunCmd::IsModelExisted(const std::string& model_id) {
         try {
           config::YamlHandler handler;
           handler.ModelConfigFromFile(entry.path().string());
-          std::cout << entry.path().stem().string() << std::endl;
           if (entry.path().stem().string() == model_id) {
             return true;
           }

--- a/engine/controllers/processManager.cc
+++ b/engine/controllers/processManager.cc
@@ -1,11 +1,17 @@
 #include "processManager.h"
-#include <cstdlib>
+#include "utils/cortex_utils.h"
+
 #include <trantor/utils/Logger.h>
+#include <cstdlib>
 
 void processManager::destroy(
-    const HttpRequestPtr &req,
-    std::function<void(const HttpResponsePtr &)> &&callback) {
+    const HttpRequestPtr& req,
+    std::function<void(const HttpResponsePtr&)>&& callback) {
+  app().quit();
+  Json::Value ret;
+  ret["message"] = "Program is exitting, goodbye!";
+  auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
+  resp->setStatusCode(k200OK);
+  callback(resp);
   LOG_INFO << "Program is exitting, goodbye!";
-  exit(0);
-  return;
 };


### PR DESCRIPTION
http connection closes when we send `stop` to server
```
.\cortex-cpp.exe stop
20240829 08:20:13.669000 UTC 6056 WARN  HTTP error: Failed to read connection - stop_server_cmd.cc:16
```
should do it better
```
.\cortex-cpp.exe stop
20240829 08:31:55.266000 UTC 12584 INFO  {"message":"Program is exitting, goodbye!"} - stop_server_cmd.cc:13
```