### PR TITLE
chore: add variant support

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -59,6 +59,10 @@ if(DEBUG)
   add_compile_definitions(ALLOW_ALL_CORS)
 endif()
 
+if(NOT DEFINED CORTEX_VARIANT)
+  set(CORTEX_VARIANT "prod")
+endif()
+
 if(NOT DEFINED CORTEX_CONFIG_FILE_PATH)
   set(CORTEX_CONFIG_FILE_PATH "user_home")
 endif()
@@ -83,6 +87,7 @@ if(DEFINED CMAKE_JS_INC)
   add_compile_definitions(NAPI_VERSION=8)
 endif()
 
+add_compile_definitions(CORTEX_VARIANT="${CORTEX_VARIANT}")
 add_compile_definitions(CORTEX_CPP_VERSION="${CORTEX_CPP_VERSION}")
 add_compile_definitions(CORTEX_CONFIG_FILE_PATH="${CORTEX_CONFIG_FILE_PATH}")
 


### PR DESCRIPTION
## Describe Your Changes

- Adding support for 3 variants: `prod`, `beta` and `nightly`
- Flag added to build command: `-DCORTEX_VARIANT=beta`

## Screenshots
Test with `beta` env. To pull model
Expectation:
- [x] Configuration file created: `Config file not found. Creating one at /Users/jamesnguyen/.cortexrc-beta`
<img width="1009" alt="Screenshot 2024-09-06 at 15 32 10" src="https://github.com/user-attachments/assets/feaaeabd-c745-433d-b93d-fb8fdd1e9e84">

- [x] Model downloaded at: `~/cortexcpp-beta`
<img width="434" alt="Screenshot 2024-09-06 at 15 33 41" src="https://github.com/user-attachments/assets/2ae739f9-57c3-463a-bf3e-4f70e8dcb45b">

## Fixes Issues

- #1031 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed