### PR TITLE
feat: add pytest for e2e testing

### DIFF
--- a/engine/controllers/command_line_parser.cc
+++ b/engine/controllers/command_line_parser.cc
@@ -138,7 +138,6 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
     });
 
     auto install_cmd = engines_cmd->add_subcommand("install", "Install engine");
-    install_cmd->callback([] { CLI_LOG("Engine name can't be empty!"); });
     for (auto& engine : engine_service_.kSupportEngines) {
       std::string engine_name{engine};
       EngineInstall(install_cmd, engine_name, version);
@@ -146,7 +145,6 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
 
     auto uninstall_cmd =
         engines_cmd->add_subcommand("uninstall", "Uninstall engine");
-    uninstall_cmd->callback([] { CLI_LOG("Engine name can't be empty!"); });
     for (auto& engine : engine_service_.kSupportEngines) {
       std::string engine_name{engine};
       EngineUninstall(uninstall_cmd, engine_name);

--- a/engine/e2e-test/main.py
+++ b/engine/e2e-test/main.py
@@ -1,7 +1,7 @@
 import pytest
-
-from test_cli_engine_list import TestCliEngineList
+from test_api_engine_list import TestApiEngineList
 from test_cli_engine_get import TestCliEngineGet
+from test_cli_engine_list import TestCliEngineList
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/engine/e2e-test/main.py
+++ b/engine/e2e-test/main.py
@@ -1,7 +1,9 @@
 import pytest
 from test_api_engine_list import TestApiEngineList
 from test_cli_engine_get import TestCliEngineGet
+from test_cli_engine_install import TestCliEngineInstall
 from test_cli_engine_list import TestCliEngineList
+from test_cli_engine_uninstall import TestCliEngineUninstall
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/engine/e2e-test/main.py
+++ b/engine/e2e-test/main.py
@@ -1,0 +1,7 @@
+import pytest
+
+from test_cli_engine_list import TestCliEngineList
+from test_cli_engine_get import TestCliEngineGet
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/engine/e2e-test/test_api_engine_list.py
+++ b/engine/e2e-test/test_api_engine_list.py
@@ -8,7 +8,9 @@ class TestApiEngineList:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         # Setup
-        start_server()
+        success = start_server()
+        if not success:
+            raise Exception("Failed to start server")
 
         yield
 

--- a/engine/e2e-test/test_api_engine_list.py
+++ b/engine/e2e-test/test_api_engine_list.py
@@ -1,0 +1,20 @@
+import pytest
+import requests
+from test_runner import start_server, stop_server
+
+
+class TestApiEngineList:
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        # Setup
+        start_server()
+
+        yield
+
+        # Teardown
+        stop_server()
+
+    def test_engines_list_api_run_successfully(self):
+        response = requests.get("http://localhost:3928/engines")
+        assert response.status_code == 200

--- a/engine/e2e-test/test_cli_engine_get.py
+++ b/engine/e2e-test/test_cli_engine_get.py
@@ -5,23 +5,52 @@ from test_runner import run
 
 
 class TestCliEngineGet:
+
     @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
-    def test_engines_list_run_successfully_on_windows(self):
-        # TODO: implement
-        assert 0 == 0
+    def test_engines_get_tensorrt_llm_should_not_be_incompatible(self):
+        exit_code, output, error = run(
+            "Get engine", ["engines", "get", "cortex.tensorrt-llm"]
+        )
+        assert exit_code == 0, f"Get engine failed with error: {error}"
+        assert (
+            "Incompatible" not in output
+        ), "cortex.tensorrt-llm should be Ready or Not Installed on Windows"
+
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
+    def test_engines_get_onnx_should_not_be_incompatible(self):
+        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.onnx"])
+        assert exit_code == 0, f"Get engine failed with error: {error}"
+        assert (
+            "Incompatible" not in output
+        ), "cortex.onnx should be Ready or Not Installed on Windows"
+
+    def test_engines_get_llamacpp_should_not_be_incompatible(self):
+        exit_code, output, error = run(
+            "Get engine", ["engines", "get", "cortex.llamacpp"]
+        )
+        assert exit_code == 0, f"Get engine failed with error: {error}"
+        assert (
+            "Incompatible" not in output
+        ), "cortex.llamacpp should be compatible for Windows, MacOs and Linux"
 
     @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
-    def test_engines_get_run_successfully_on_macos(self):
-        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.llamacpp"])
+    def test_engines_get_tensorrt_llm_should_be_incompatible_on_macos(self):
+        exit_code, output, error = run(
+            "Get engine", ["engines", "get", "cortex.tensorrt-llm"]
+        )
         assert exit_code == 0, f"Get engine failed with error: {error}"
+        assert (
+            "Incompatible" in output
+        ), "cortex.tensorrt-llm should be Incompatible on MacOS"
 
     @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
-    def test_engines_get_llamacpp_on_macos(self):
-        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.llamacpp"])
+    def test_engines_get_onnx_should_be_incompatible_on_macos(self):
+        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.onnx"])
         assert exit_code == 0, f"Get engine failed with error: {error}"
-        assert "Incompatible" not in output, f"cortex.llamacpp can only be Ready or Not Installed"
+        assert "Incompatible" in output, "cortex.onnx should be Incompatible on MacOS"
 
     @pytest.mark.skipif(platform.system() != "Linux", reason="Linux-specific test")
-    def test_engines_list_run_successfully_on_linux(self):
-        # TODO: implement
-        assert 0 == 0
+    def test_engines_get_onnx_should_be_incompatible_on_linux(self):
+        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.onnx"])
+        assert exit_code == 0, f"Get engine failed with error: {error}"
+        assert "Incompatible" in output, "cortex.onnx should be Incompatible on Linux"

--- a/engine/e2e-test/test_cli_engine_get.py
+++ b/engine/e2e-test/test_cli_engine_get.py
@@ -1,0 +1,27 @@
+import platform
+
+import pytest
+from test_runner import run
+
+
+class TestCliEngineGet:
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
+    def test_engines_list_run_successfully_on_windows(self):
+        # TODO: implement
+        assert 0 == 0
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
+    def test_engines_get_run_successfully_on_macos(self):
+        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.llamacpp"])
+        assert exit_code == 0, f"Get engine failed with error: {error}"
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
+    def test_engines_get_llamacpp_on_macos(self):
+        exit_code, output, error = run("Get engine", ["engines", "get", "cortex.llamacpp"])
+        assert exit_code == 0, f"Get engine failed with error: {error}"
+        assert "Incompatible" not in output, f"cortex.llamacpp can only be Ready or Not Installed"
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Linux-specific test")
+    def test_engines_list_run_successfully_on_linux(self):
+        # TODO: implement
+        assert 0 == 0

--- a/engine/e2e-test/test_cli_engine_install.py
+++ b/engine/e2e-test/test_cli_engine_install.py
@@ -1,0 +1,30 @@
+import platform
+
+import pytest
+from test_runner import run
+
+
+class TestCliEngineInstall:
+
+    def test_engines_install_llamacpp_should_be_successfully(self):
+        exit_code, output, error = run(
+            "Install Engine", ["engines", "install", "cortex.llamacpp"]
+        )
+        assert "Download" in output, "Should display downloading message"
+        assert exit_code == 0, f"Install engine failed with error: {error}"
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
+    def test_engines_install_onnx_on_macos_should_be_failed(self):
+        exit_code, output, error = run(
+            "Install Engine", ["engines", "install", "cortex.onnx"]
+        )
+        assert "No variant found" in output, "Should display error message"
+        assert exit_code == 0, f"Install engine failed with error: {error}"
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
+    def test_engines_install_onnx_on_tensorrt_should_be_failed(self):
+        exit_code, output, error = run(
+            "Install Engine", ["engines", "install", "cortex.tensorrt-llm"]
+        )
+        assert "No variant found" in output, "Should display error message"
+        assert exit_code == 0, f"Install engine failed with error: {error}"

--- a/engine/e2e-test/test_cli_engine_list.py
+++ b/engine/e2e-test/test_cli_engine_list.py
@@ -1,0 +1,24 @@
+import platform
+
+import pytest
+from test_runner import run
+
+
+class TestCliEngineList:
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
+    def test_engines_list_run_successfully_on_windows(self):
+        exit_code, output, error = run("List engines", ["engines", "list"])
+        assert exit_code == 0, f"List engines failed with error: {error}"
+        assert "llama.cpp" in output
+
+    @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS-specific test")
+    def test_engines_list_run_successfully_on_macos(self):
+        exit_code, output, error = run("List engines", ["engines", "list"])
+        assert exit_code == 0, f"List engines failed with error: {error}"
+        assert "llama.cpp" in output
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Linux-specific test")
+    def test_engines_list_run_successfully_on_linux(self):
+        exit_code, output, error = run("List engines", ["engines", "list"])
+        assert exit_code == 0, f"List engines failed with error: {error}"
+        assert "llama.cpp" in output

--- a/engine/e2e-test/test_cli_engine_uninstall.py
+++ b/engine/e2e-test/test_cli_engine_uninstall.py
@@ -1,0 +1,24 @@
+import pytest
+from test_runner import run
+
+
+class TestCliEngineUninstall:
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        # Setup
+        # Preinstall llamacpp engine
+        run("Install Engine", ["engines", "install", "cortex.llamacpp"])
+
+        yield
+
+        # Teardown
+        # Clean up, removing installed engine
+        run("Uninstall Engine", ["engines", "uninsatll", "cortex.llamacpp"])
+
+    def test_engines_uninstall_llamacpp_should_be_successfully(self):
+        exit_code, output, error = run(
+            "Uninstall engine", ["engines", "uninstall", "cortex.llamacpp"]
+        )
+        assert "Engine cortex.llamacpp uninstalled successfully!" in output
+        assert exit_code == 0, f"Install engine failed with error: {error}"

--- a/engine/e2e-test/test_cli_engine_uninstall.py
+++ b/engine/e2e-test/test_cli_engine_uninstall.py
@@ -14,7 +14,7 @@ class TestCliEngineUninstall:
 
         # Teardown
         # Clean up, removing installed engine
-        run("Uninstall Engine", ["engines", "uninsatll", "cortex.llamacpp"])
+        run("Uninstall Engine", ["engines", "uninstall", "cortex.llamacpp"])
 
     def test_engines_uninstall_llamacpp_should_be_successfully(self):
         exit_code, output, error = run(

--- a/engine/e2e-test/test_runner.py
+++ b/engine/e2e-test/test_runner.py
@@ -1,36 +1,55 @@
 import platform
+import queue
 import select
 import subprocess
+import threading
 import time
 from typing import List
 
+# You might want to change the path of the executable based on your build directory
+executable_windows_path = "build\\Debug\\cortex.exe"
+executable_unix_path = "build/cortex"
 
-def run(name: str, arguments: List[str]):
+# Timeout
+timeout = 5  # secs
+start_server_success_message = "Server started"
+
+
+# Get the executable path based on the platform
+def getExecutablePath() -> str:
     if platform.system() == "Windows":
-        executable = "build\\cortex-cpp.exe"
+        return executable_windows_path
     else:
-        executable = "build/cortex-cpp"
-    print("Command name", name)
-    print("Running command: ", [executable] + arguments)
-    if len(arguments) == 0:
-        result = subprocess.run(executable, capture_output=True, text=True, timeout=5)
-    else:
-        result = subprocess.run(
-            [executable] + arguments, capture_output=True, text=True, timeout=5
-        )
+        return executable_unix_path
+
+
+# Execute a command
+def run(test_name: str, arguments: List[str]):
+    executable_path = getExecutablePath()
+    print("Running:", test_name)
+    print("Command:", [executable_path] + arguments)
+
+    result = subprocess.run(
+        [executable_path] + arguments, capture_output=True, text=True, timeout=timeout
+    )
     return result.returncode, result.stdout, result.stderr
 
 
-def start_server(timeout=5):
+# Start the API server
+# Wait for `Server started` message or failed
+def start_server() -> bool:
     if platform.system() == "Windows":
-        executable = "build\\cortex-cpp.exe"
+        return start_server_windows()
     else:
-        executable = "build/cortex-cpp"
+        return start_server_nix()
+
+
+def start_server_nix() -> bool:
+    executable = getExecutablePath()
     process = subprocess.Popen(
         executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
     )
 
-    success_message = "Server started"
     start_time = time.time()
     while time.time() - start_time < timeout:
         # Use select to check if there's data to read from stdout or stderr
@@ -39,18 +58,80 @@ def start_server(timeout=5):
         for stream in readable:
             line = stream.readline()
             if line:
-                print(line.strip())  # Print output for debugging
-                if success_message in line:
+                if start_server_success_message in line:
                     # have to wait a bit for server to really up and accept connection
+                    print("Server started found, wait 0.3 sec..")
                     time.sleep(0.3)
-                    return True, process  # Success condition met
+                    return True
 
         # Check if the process has ended
         if process.poll() is not None:
-            return False, process  # Process ended without success message
+            return False
 
-    return False, process  # Timeout reached
+    return False
 
 
+def start_server_windows() -> bool:
+    executable = getExecutablePath()
+    process = subprocess.Popen(
+        executable,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
+    )
+
+    q_out = queue.Queue()
+    q_err = queue.Queue()
+
+    def enqueue_output(out, queue):
+        for line in iter(out.readline, b""):
+            queue.put(line)
+        out.close()
+
+    # Start threads to read stdout and stderr
+    t_out = threading.Thread(target=enqueue_output, args=(process.stdout, q_out))
+    t_err = threading.Thread(target=enqueue_output, args=(process.stderr, q_err))
+    t_out.daemon = True
+    t_err.daemon = True
+    t_out.start()
+    t_err.start()
+
+    # only wait for defined timeout
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        # Check stdout
+        try:
+            line = q_out.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            print(f"STDOUT: {line.strip()}")
+            if start_server_success_message in line:
+                return True
+
+        # Check stderr
+        try:
+            line = q_err.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            print(f"STDERR: {line.strip()}")
+            if start_server_success_message in line:
+                # found the message. let's wait for some time for the server successfully started
+                time.sleep(0.3)
+                return True, process
+
+        # Check if the process has ended
+        if process.poll() is not None:
+            return False
+
+        time.sleep(0.1)
+
+    return False
+
+
+# Stop the API server
 def stop_server():
     run("Stop server", ["stop"])

--- a/engine/e2e-test/test_runner.py
+++ b/engine/e2e-test/test_runner.py
@@ -1,0 +1,13 @@
+import platform
+import subprocess
+import os
+from typing import List, Tuple
+
+
+def run(name: str, arguments: List[str]):
+    if platform.system() == "Windows":
+        executable = "build\\cortex-cpp.exe"
+    else:
+        executable = "build/cortex-cpp"
+    result = subprocess.run([executable] + arguments, capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr

--- a/engine/e2e-test/test_runner.py
+++ b/engine/e2e-test/test_runner.py
@@ -1,7 +1,8 @@
 import platform
+import select
 import subprocess
-import os
-from typing import List, Tuple
+import time
+from typing import List
 
 
 def run(name: str, arguments: List[str]):
@@ -9,5 +10,47 @@ def run(name: str, arguments: List[str]):
         executable = "build\\cortex-cpp.exe"
     else:
         executable = "build/cortex-cpp"
-    result = subprocess.run([executable] + arguments, capture_output=True, text=True)
+    print("Command name", name)
+    print("Running command: ", [executable] + arguments)
+    if len(arguments) == 0:
+        result = subprocess.run(executable, capture_output=True, text=True, timeout=5)
+    else:
+        result = subprocess.run(
+            [executable] + arguments, capture_output=True, text=True, timeout=5
+        )
     return result.returncode, result.stdout, result.stderr
+
+
+def start_server(timeout=5):
+    if platform.system() == "Windows":
+        executable = "build\\cortex-cpp.exe"
+    else:
+        executable = "build/cortex-cpp"
+    process = subprocess.Popen(
+        executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+
+    success_message = "Server started"
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        # Use select to check if there's data to read from stdout or stderr
+        readable, _, _ = select.select([process.stdout, process.stderr], [], [], 0.1)
+
+        for stream in readable:
+            line = stream.readline()
+            if line:
+                print(line.strip())  # Print output for debugging
+                if success_message in line:
+                    # have to wait a bit for server to really up and accept connection
+                    time.sleep(0.3)
+                    return True, process  # Success condition met
+
+        # Check if the process has ended
+        if process.poll() is not None:
+            return False, process  # Process ended without success message
+
+    return False, process  # Timeout reached
+
+
+def stop_server():
+    run("Stop server", ["stop"])

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -27,7 +27,8 @@
 
 void RunServer() {
   auto config = file_manager_utils::GetCortexConfig();
-  LOG_INFO << "Host: " << config.apiServerHost << " Port: " << config.apiServerPort << "\n";
+  LOG_INFO << "Host: " << config.apiServerHost
+           << " Port: " << config.apiServerPort << "\n";
 
   // Create logs/ folder and setup log to file
   std::filesystem::create_directory(config.logFolderPath + "/" +
@@ -72,7 +73,8 @@ void RunServer() {
   LOG_INFO << "Server started, listening at: " << config.apiServerHost << ":"
            << config.apiServerPort;
   LOG_INFO << "Please load your model";
-  drogon::app().addListener(config.apiServerHost, std::stoi(config.apiServerPort));
+  drogon::app().addListener(config.apiServerHost,
+                            std::stoi(config.apiServerPort));
   drogon::app().setThreadNum(drogon_thread_num);
   LOG_INFO << "Number of thread is:" << drogon::app().getThreadNum();
 

--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -71,8 +71,6 @@ std::vector<EngineInfo> EngineService::GetEngineInfoList() const {
 }
 
 void EngineService::UninstallEngine(const std::string& engine) {
-  CTL_INF("Uninstall engine " + engine);
-
   // TODO: Unload the model which is currently running on engine_
 
   // TODO: Unload engine if is loaded


### PR DESCRIPTION
## Describe Your Changes

- Sample testing for our CLI and API server

## Items
- [x] Engine list
- [x] Engine get
- [x] Engine install
- [x] Engine uninstall
- [x] Adding some tests for HTTP request

## How to use
0. Build cortex binary first. Binary should be available at `engine/build/cortex-cpp`
1. Install python
2. `pip install pytest requests`
2.1. On windows, I have to use `pip install pytest requests --user`
4. `python e2e-test/main.py`

## Remaining things to do
- [x] Retest on windows to see if this works as expected
- [ ] Wiring with our CI/CD?

## Screenshots
<img width="1646" alt="Screenshot 2024-09-11 at 12 38 11" src="https://github.com/user-attachments/assets/f3091b2e-6974-4db9-b6c6-f3fb77339f69">

### windows
![image](https://github.com/user-attachments/assets/e69a6c6f-1891-4d1c-b999-e4b1ced97924)

## Sample output
```
~/w/c/engine ❯❯❯ python e2e-test/main.py
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.11.4, pytest-8.3.2, pluggy-1.5.0 -- /Users/jamesnguyen/.pyenv/versions/3.11.4/bin/python
cachedir: .pytest_cache
rootdir: /Users/jamesnguyen/workspace/cortex/engine
plugins: anyio-4.3.0
collected 7 items                                                                                                                                              

e2e-test/main.py::TestCliEngineList::test_engines_list_run_successfully_on_windows SKIPPED (Windows-specific test)                                       [ 14%]
e2e-test/main.py::TestCliEngineList::test_engines_list_run_successfully_on_macos PASSED                                                                  [ 28%]
e2e-test/main.py::TestCliEngineList::test_engines_list_run_successfully_on_linux SKIPPED (Linux-specific test)                                           [ 42%]
e2e-test/main.py::TestCliEngineGet::test_engines_list_run_successfully_on_windows SKIPPED (Windows-specific test)                                        [ 57%]
e2e-test/main.py::TestCliEngineGet::test_engines_get_run_successfully_on_macos PASSED                                                                    [ 71%]
e2e-test/main.py::TestCliEngineGet::test_engines_get_llamacpp_on_macos PASSED                                                                            [ 85%]
e2e-test/main.py::TestCliEngineGet::test_engines_list_run_successfully_on_linux SKIPPED (Linux-specific test)                                            [100%]

================================================================= 3 passed, 4 skipped in 2.12s =================================================================

```

## Fixes Issues

- #1147

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed