### PR TITLE
Fix issue postinstaller not run in macos

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -97,6 +97,7 @@ jobs:
   
   update-latest-version:
     runs-on: ubuntu-latest
+    if: needs.set-public-provider.outputs.public_provider == 'aws-s3'
     needs: [get-update-version, set-public-provider, build-linux-x64, build-macos-x64, build-macos-arm64, build-windows-x64]
     steps:
       - name: Update latest version

--- a/.github/workflows/template-build-macos.yml
+++ b/.github/workflows/template-build-macos.yml
@@ -1,4 +1,4 @@
-name: build-mac-x64
+name: build-mac
 on:
   workflow_call:
     inputs:
@@ -174,13 +174,18 @@ jobs:
         run: |
           cd engine
           make build-installer PACKAGE_NAME="${{ steps.set-output-params.outputs.package_name }}" VERSION=${{ inputs.new_version }} SOURCE_BINARY_PATH="../../cortex/${{ steps.set-output-params.outputs.destination_binary_name }}" DESTINATION_BINARY_NAME="${{ steps.set-output-params.outputs.destination_binary_name }}" DATA_FOLDER_NAME="${{ steps.set-output-params.outputs.data_folder_name }}" CONFIGURATION_FILE_NAME="${{ steps.set-output-params.outputs.configuration_file_name }}" UNINSTALLER_FILE_NAME="${{ steps.set-output-params.outputs.uninstaller_file_name }}"
+          cat templates/macos/Scripts/postinstall
 
       - name: Codesign and notary for macos installer
         run: |
           cd engine
           productsign --sign "Developer ID Installer: ${{ secrets.DEVELOPER_ID }}" ${{ steps.set-output-params.outputs.package_name }}.pkg ${{ steps.set-output-params.outputs.package_name }}$-signed.pkg
           rm ${{ steps.set-output-params.outputs.package_name }}.pkg
-          mv ${{ steps.set-output-params.outputs.package_name }}$-signed.pkg ${{ steps.set-output-params.outputs.package_name }}.pkg
+          mv ${{ steps.set-output-params.outputs.package_name }}$-signed.pkg Distribution.pkg
+          productbuild --synthesize --package Distribution.pkg Distribution.xml
+          sed -i '' 's/require-scripts="false"/require-scripts="true"/' Distribution.xml
+          cat Distribution.xml
+          productbuild --distribution Distribution.xml --sign "Developer ID Installer: ${{ secrets.DEVELOPER_ID }}" --package-path . ${{ steps.set-output-params.outputs.package_name }}.pkg
           xcrun notarytool submit ${{ steps.set-output-params.outputs.package_name }}.pkg --apple-id ${{ secrets.APPLE_ID }} --password ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }} --team-id ${{ secrets.APPLE_TEAM_ID }} --wait
 
       - name: Package

--- a/engine/templates/macos/cortex-uninstall.sh
+++ b/engine/templates/macos/cortex-uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 DESTINATION_BINARY_NAME=cortex
 DATA_FOLDER_NAME=.cortex
 CONFIGURATION_FILE_NAME=.cortexrc

--- a/engine/templates/macos/create_pkg.sh
+++ b/engine/templates/macos/create_pkg.sh
@@ -13,7 +13,7 @@ cp $SOURCE_BINARY_PATH installer/$DESTINATION_BINARY_NAME
 
 export DESTINATION_BINARY_NAME
 cp postinstall Scripts/postinstall
-sed -i '' "2s/.*/DESTINATION_BINARY_NAME=$DESTINATION_BINARY_NAME/" Scripts/postinstall
+sed -i '' "3s/.*/DESTINATION_BINARY_NAME=$DESTINATION_BINARY_NAME/" Scripts/postinstall
 
 export DATA_FOLDER_NAME CONFIGURATION_FILE_NAME UNINSTALLER_FILE_NAME
 cp cortex-uninstall.sh installer/$UNINSTALLER_FILE_NAME

--- a/engine/templates/macos/create_pkg.sh
+++ b/engine/templates/macos/create_pkg.sh
@@ -14,6 +14,7 @@ cp $SOURCE_BINARY_PATH installer/$DESTINATION_BINARY_NAME
 export DESTINATION_BINARY_NAME
 cp postinstall Scripts/postinstall
 sed -i '' "3s/.*/DESTINATION_BINARY_NAME=$DESTINATION_BINARY_NAME/" Scripts/postinstall
+chmod +x Scripts/postinstall
 
 export DATA_FOLDER_NAME CONFIGURATION_FILE_NAME UNINSTALLER_FILE_NAME
 cp cortex-uninstall.sh installer/$UNINSTALLER_FILE_NAME

--- a/engine/templates/macos/create_pkg.sh
+++ b/engine/templates/macos/create_pkg.sh
@@ -7,13 +7,13 @@ CONFIGURATION_FILE_NAME=$6
 UNINSTALLER_FILE_NAME=$7
 
 mkdir installer
-mkdir scripts
+mkdir Scripts
 
 cp $SOURCE_BINARY_PATH installer/$DESTINATION_BINARY_NAME
 
 export DESTINATION_BINARY_NAME
-cp post-installer.sh scripts/post-installer.sh
-sed -i '' '2s/.*/DESTINATION_BINARY_NAME=\$DESTINATION_BINARY_NAME/' $PACKAGE_NAME/DEBIAN/postinst
+cp postinstall Scripts/postinstall
+sed -i '' "2s/.*/DESTINATION_BINARY_NAME=$DESTINATION_BINARY_NAME/" Scripts/postinstall
 
 export DATA_FOLDER_NAME CONFIGURATION_FILE_NAME UNINSTALLER_FILE_NAME
 cp cortex-uninstall.sh installer/$UNINSTALLER_FILE_NAME
@@ -22,4 +22,4 @@ sed -i '' "3s/.*/DATA_FOLDER_NAME=$DATA_FOLDER_NAME/" installer/$UNINSTALLER_FIL
 sed -i '' "4s/.*/CONFIGURATION_FILE_NAME=$CONFIGURATION_FILE_NAME/" installer/$UNINSTALLER_FILE_NAME
 sed -i '' "5s/.*/UNINSTALLER_FILE_NAME=$UNINSTALLER_FILE_NAME/" installer/$UNINSTALLER_FILE_NAME
 
-pkgbuild --identifier ai.cortexcpp.pkg --version $VERSION --scripts scripts --install-location /usr/local/bin --root ./installer ${PACKAGE_NAME}.pkg
+pkgbuild --identifier ai.cortexcpp.pkg --version $VERSION --scripts Scripts --install-location /usr/local/bin --root ./installer ${PACKAGE_NAME}.pkg

--- a/engine/templates/macos/postinstall
+++ b/engine/templates/macos/postinstall
@@ -1,5 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
+set -e
 DESTINATION_BINARY_NAME=cortex
 USER_TO_RUN_AS=${SUDO_USER:-$(whoami)}
 echo "Download cortex.llamacpp engines by default"
 sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME engines install cortex.llamacpp
+
+exit 0


### PR DESCRIPTION
## Describe Your Changes
Currently, the macOS installer will not trigger the postinstall script because it is just a single pkg file, not a productbuild. This PR aims to fix the issue of the postinstall script not running on macOS by converting it to a productbuild pkg file.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed