### PR TITLE
feat: add hardware-info binary

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -63,11 +63,14 @@ add_compile_definitions(CORTEX_CPP_VERSION="${CORTEX_CPP_VERSION}")
 add_compile_definitions(CORTEX_CONFIG_FILE_PATH="${CORTEX_CONFIG_FILE_PATH}")
 
 option(CMAKE_BUILD_TEST "Enable testing" OFF)
+option(BUILD_HARDWARE_INFO "Enable build hardware info" ON)
 if(CMAKE_BUILD_TEST)
   add_subdirectory(test)
 endif()
 
-add_subdirectory(examples/hardware-info)
+if(BUILD_HARDWARE_INFO)
+  add_subdirectory(examples/hardware-info)
+endif()
 
 find_package(jsoncpp CONFIG REQUIRED)
 find_package(Drogon CONFIG REQUIRED)

--- a/engine/examples/hardware-info/CMakeLists.txt
+++ b/engine/examples/hardware-info/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(OPENSSL_USE_STATIC_LIBS TRUE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(MSVC)
@@ -39,32 +38,16 @@ endif()
  
 add_compile_definitions(HARDWARE_INFO_VERSION="${HARDWARE_INFO_VERSION}")
 
-find_package(jsoncpp CONFIG REQUIRED)
 find_package(Drogon CONFIG REQUIRED)
-find_package(yaml-cpp CONFIG REQUIRED)
-find_package(jinja2cpp CONFIG REQUIRED)
-find_package(httplib CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(CLI11 CONFIG REQUIRED)
-find_package(unofficial-minizip CONFIG REQUIRED)
-find_package(LibArchive REQUIRED)
-find_package(tabulate CONFIG REQUIRED)
-find_package(CURL REQUIRED)
 
 add_executable(
   ${TARGET_NAME} hardware_info.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/cpuid/cpu_info.cc
 )
 
-target_link_libraries(${TARGET_NAME} PRIVATE httplib::httplib)
 target_link_libraries(${TARGET_NAME} PRIVATE nlohmann_json::nlohmann_json)
-target_link_libraries(${TARGET_NAME} PRIVATE jinja2cpp)
-target_link_libraries(${TARGET_NAME} PRIVATE CLI11::CLI11)
-target_link_libraries(${TARGET_NAME} PRIVATE unofficial::minizip::minizip)
-target_link_libraries(${TARGET_NAME} PRIVATE LibArchive::LibArchive)
-target_link_libraries(${TARGET_NAME} PRIVATE tabulate::tabulate)
-target_link_libraries(${TARGET_NAME} PRIVATE CURL::libcurl)
-target_link_libraries(${TARGET_NAME} PRIVATE JsonCpp::JsonCpp Drogon::Drogon OpenSSL::SSL OpenSSL::Crypto yaml-cpp::yaml-cpp
+target_link_libraries(${TARGET_NAME} PRIVATE Drogon::Drogon
   ${CMAKE_THREAD_LIBS_INIT})
 
 # ##############################################################################
@@ -80,14 +63,4 @@ else()
   message(STATUS "use c++20")
 endif()
 
-aux_source_directory(controllers CTL_SRC)
-aux_source_directory(services SERVICES_SRC)
-aux_source_directory(common COMMON_SRC)
-aux_source_directory(models MODEL_SRC)
-aux_source_directory(cortex-common CORTEX_COMMON)
-aux_source_directory(config CONFIG_SRC)
-aux_source_directory(commands COMMANDS_SRC)
-
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)
-
-target_sources(${TARGET_NAME} PRIVATE ${COMMANDS_SRC} ${CONFIG_SRC} ${CTL_SRC} ${COMMON_SRC} ${SERVICES_SRC})

--- a/engine/examples/hardware-info/CMakeLists.txt
+++ b/engine/examples/hardware-info/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(cortex C CXX)
+project(hardware-info C CXX)
 
 include(CheckIncludeFileCXX)
 
@@ -30,44 +30,14 @@ if(MSVC)
   )
 endif()
 
-if(DEBUG)
-  message(STATUS "CORTEX-CPP DEBUG IS ON")
-  add_compile_definitions(ALLOW_ALL_CORS)
-endif()
-
-if(NOT DEFINED CORTEX_VARIANT)
-  set(CORTEX_VARIANT "prod")
-endif()
-
 set(TARGET_NAME ${PROJECT_NAME})
-if(RENAME_EXE)
-  if(CORTEX_VARIANT STREQUAL "beta")
-    set(TARGET_NAME "${PROJECT_NAME}-beta")
-  elseif(CORTEX_VARIANT STREQUAL "nightly")
-    set(TARGET_NAME "${PROJECT_NAME}-nightly")
-  else()
-    set(TARGET_NAME ${PROJECT_NAME})
-  endif()
-endif()
 
-if(NOT DEFINED CORTEX_CONFIG_FILE_PATH)
-  set(CORTEX_CONFIG_FILE_PATH "user_home")
-endif()
 
-if(NOT DEFINED CORTEX_CPP_VERSION)
-  set(CORTEX_CPP_VERSION "default_version")
+if(NOT DEFINED HARDWARE_INFO_VERSION)
+  set(HARDWARE_INFO_VERSION "default_version")
 endif()
  
-add_compile_definitions(CORTEX_VARIANT="${CORTEX_VARIANT}")
-add_compile_definitions(CORTEX_CPP_VERSION="${CORTEX_CPP_VERSION}")
-add_compile_definitions(CORTEX_CONFIG_FILE_PATH="${CORTEX_CONFIG_FILE_PATH}")
-
-option(CMAKE_BUILD_TEST "Enable testing" OFF)
-if(CMAKE_BUILD_TEST)
-  add_subdirectory(test)
-endif()
-
-add_subdirectory(examples/hardware-info)
+add_compile_definitions(HARDWARE_INFO_VERSION="${HARDWARE_INFO_VERSION}")
 
 find_package(jsoncpp CONFIG REQUIRED)
 find_package(Drogon CONFIG REQUIRED)
@@ -81,10 +51,10 @@ find_package(LibArchive REQUIRED)
 find_package(tabulate CONFIG REQUIRED)
 find_package(CURL REQUIRED)
 
-add_executable(${TARGET_NAME} main.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils/cpuid/cpu_info.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils/file_logger.cc
-  )
+add_executable(
+  ${TARGET_NAME} hardware_info.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/cpuid/cpu_info.cc
+)
 
 target_link_libraries(${TARGET_NAME} PRIVATE httplib::httplib)
 target_link_libraries(${TARGET_NAME} PRIVATE nlohmann_json::nlohmann_json)
@@ -118,6 +88,6 @@ aux_source_directory(cortex-common CORTEX_COMMON)
 aux_source_directory(config CONFIG_SRC)
 aux_source_directory(commands COMMANDS_SRC)
 
-target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} )
+target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 
 target_sources(${TARGET_NAME} PRIVATE ${COMMANDS_SRC} ${CONFIG_SRC} ${CTL_SRC} ${COMMON_SRC} ${SERVICES_SRC})

--- a/engine/examples/hardware-info/hardware_info.cc
+++ b/engine/examples/hardware-info/hardware_info.cc
@@ -1,0 +1,25 @@
+#include <iostream>
+#include "utils/engine_matcher_utils.h"
+#include "utils/system_info_utils.h"
+
+int main(int argc, char* argv[]) {
+  auto patch = [](const std::string& s) -> std::string {
+    return "\"" + s + "\"";
+  };
+  auto system_info = system_info_utils::GetSystemInfo();
+  cortex::cpuid::CpuInfo cpu_info;
+  auto suitable_avx = engine_matcher_utils::GetSuitableAvxVariant(cpu_info);
+  auto nvidia_driver = system_info_utils::GetDriverVersion();
+  auto cuda_version = system_info_utils::GetCudaVersion();
+
+  std::cout << "{" << std::endl;
+  std::cout << "\"os\": " << patch(system_info.os) << "," << std::endl;
+
+  std::cout << "\"arch\": " << patch(system_info.arch) << "," << std::endl;
+  std::cout << "\"suitable_avx\": " << patch(suitable_avx) << "," << std::endl;
+  std::cout << "\"nvidia_driver\": " << patch(nvidia_driver) << ","
+            << std::endl;
+  std::cout << "\"cuda_version\": " << patch(cuda_version) << std::endl;
+  std::cout << "}" << std::endl;
+  return 0;
+}

--- a/engine/examples/hardware-info/hardware_info.cc
+++ b/engine/examples/hardware-info/hardware_info.cc
@@ -1,25 +1,35 @@
 #include <iostream>
+#include "nlohmann/json.hpp"
 #include "utils/engine_matcher_utils.h"
 #include "utils/system_info_utils.h"
 
 int main(int argc, char* argv[]) {
-  auto patch = [](const std::string& s) -> std::string {
-    return "\"" + s + "\"";
-  };
+  trantor::Logger::setLogLevel(trantor::Logger::kFatal);
   auto system_info = system_info_utils::GetSystemInfo();
   cortex::cpuid::CpuInfo cpu_info;
   auto suitable_avx = engine_matcher_utils::GetSuitableAvxVariant(cpu_info);
-  auto nvidia_driver = system_info_utils::GetDriverVersion();
-  auto cuda_version = system_info_utils::GetCudaVersion();
+  auto gpu_info_list = system_info_utils::GetGpuInfoList();
 
-  std::cout << "{" << std::endl;
-  std::cout << "\"os\": " << patch(system_info.os) << "," << std::endl;
-
-  std::cout << "\"arch\": " << patch(system_info.arch) << "," << std::endl;
-  std::cout << "\"suitable_avx\": " << patch(suitable_avx) << "," << std::endl;
-  std::cout << "\"nvidia_driver\": " << patch(nvidia_driver) << ","
-            << std::endl;
-  std::cout << "\"cuda_version\": " << patch(cuda_version) << std::endl;
-  std::cout << "}" << std::endl;
+  nlohmann::ordered_json json_data;
+  json_data["os"] = system_info.os;
+  json_data["arch"] = system_info.arch;
+  json_data["suitable_avx"] = suitable_avx;
+  json_data["gpu_info"] = nlohmann::json::array();
+  for (auto& gpu_info : gpu_info_list) {
+    nlohmann::ordered_json info;
+    info["id"] = gpu_info.id;
+    info["name"] = gpu_info.name;
+    info["arch"] = gpu_info.arch;
+    info["driver_version"] = gpu_info.driver_version.has_value()
+                                 ? gpu_info.driver_version.value()
+                                 : "";
+    info["cuda_driver_version"] = gpu_info.cuda_driver_version.has_value()
+                                      ? gpu_info.cuda_driver_version.value()
+                                      : "";
+    info["compute_cap"] =
+        gpu_info.compute_cap.has_value() ? gpu_info.compute_cap.value() : "";
+    json_data["gpu_info"].push_back(info);
+  }
+  std::cout << json_data.dump() << std::endl;
   return 0;
 }

--- a/engine/utils/system_info_utils.h
+++ b/engine/utils/system_info_utils.h
@@ -4,6 +4,7 @@
 #include <regex>
 #include <sstream>
 #include <vector>
+#include <optional>
 #include "utils/command_executor.h"
 #include "utils/logging_utils.h"
 #ifdef _WIN32

--- a/engine/utils/system_info_utils.h
+++ b/engine/utils/system_info_utils.h
@@ -218,7 +218,11 @@ inline std::vector<GpuInfo> GetGpuInfoListVulkan() {
 
 inline std::vector<GpuInfo> GetGpuInfoList() {
   std::vector<GpuInfo> gpuInfoList;
-
+  if (!IsNvidiaSmiAvailable()) {
+    CTL_INF("nvidia-smi is not available!");
+    return gpuInfoList;
+  };
+  
   try {
     // TODO: improve by parsing both in one command execution
     auto driver_version = GetDriverVersion();


### PR DESCRIPTION
## Describe Your Changes

- This is a PR to solve a part of https://github.com/janhq/cortex.cpp/issues/1217. We use `hardware-info` to detect CPU instructions and Nvidia GPU if supported.
Output example:
```
{"os":"windows","arch":"amd64","suitable_avx":"avx2","gpu_info":[{"id":"0","name":"NVIDIA GeForce RTX 3090","arch":"ampere","driver_version":"552.12","cuda_driver_version":"12.4","compute_cap":"8.6"}]}
```

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed