### PR TITLE
Feat/model import cmd

### DIFF
--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -33,6 +33,7 @@ void ModelImportCmd::Exec() {
     gguf_handler.Parse(model_path_);
     config::ModelConfig model_config = gguf_handler.GetModelConfig();
     model_config.files.push_back(model_path_);
+    model_config.name = model_handle_;
     yaml_handler.UpdateModelConfig(model_config);
 
     if(modellist_utils_obj.AddModelEntry(model_entry)){

--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -36,18 +36,19 @@ void ModelImportCmd::Exec() {
     model_config.name = model_handle_;
     yaml_handler.UpdateModelConfig(model_config);
 
-    if(modellist_utils_obj.AddModelEntry(model_entry)){
-        yaml_handler.WriteYamlFile(model_yaml_path);
-        CLI_LOG("Model is imported successfully!");
+    if (modellist_utils_obj.AddModelEntry(model_entry)) {
+      yaml_handler.WriteYamlFile(model_yaml_path);
+      CLI_LOG("Model is imported successfully!");
+    } else {
+      CLI_LOG("Fail to import model, model_id '" + model_handle_ +
+              "' already exists!");
     }
-    else{
-        CLI_LOG("Fail to import model, model_id '"+model_handle_+"' already exists!" );
-    }
-    
+
   } catch (const std::exception& e) {
     std::remove(model_yaml_path.c_str());
-    CTL_ERR("Error importing model '" << model_path_ << "' with model_id '"
-                                      << model_handle_ << "': " << e.what());
+    throw std::runtime_error("Error importing model '" + model_path_ +
+                             "' with model_id '" + model_handle_ +
+                             "': " + e.what());
   }
 }
 }  // namespace commands

--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -1,0 +1,52 @@
+#include "model_import_cmd.h"
+#include <filesystem>
+#include <iostream>
+#include <vector>
+#include "config/gguf_parser.h"
+#include "config/yaml_config.h"
+#include "trantor/utils/Logger.h"
+#include "utils/file_manager_utils.h"
+#include "utils/logging_utils.h"
+#include "utils/modellist_utils.h"
+
+namespace commands {
+
+ModelImportCmd::ModelImportCmd(std::string model_handle, std::string model_path)
+    : model_handle_(std::move(model_handle)),
+      model_path_(std::move(model_path)) {}
+
+void ModelImportCmd::Exec() {
+  config::GGUFHandler gguf_handler;
+  config::YamlHandler yaml_handler;
+  modellist_utils::ModelListUtils modellist_utils_obj;
+
+  std::string model_yaml_path = (file_manager_utils::GetModelsContainerPath() /
+                                 std::filesystem::path("imported") /
+                                 std::filesystem::path(model_handle_ + ".yml"))
+                                    .string();
+  modellist_utils::ModelEntry model_entry{
+      model_handle_,   "local",       "imported",
+      model_yaml_path, model_handle_, modellist_utils::ModelStatus::READY};
+  try {
+    std::filesystem::create_directories(
+        std::filesystem::path(model_yaml_path).parent_path());
+    gguf_handler.Parse(model_path_);
+    config::ModelConfig model_config = gguf_handler.GetModelConfig();
+    model_config.files.push_back(model_path_);
+    yaml_handler.UpdateModelConfig(model_config);
+
+    if(modellist_utils_obj.AddModelEntry(model_entry)){
+        yaml_handler.WriteYamlFile(model_yaml_path);
+        CLI_LOG("Model is imported successfully!");
+    }
+    else{
+        CLI_LOG("Fail to import model, model_id '"+model_handle_+"' already exists!" );
+    }
+    
+  } catch (const std::exception& e) {
+    std::remove(model_yaml_path.c_str());
+    CTL_ERR("Error importing model '" << model_path_ << "' with model_id '"
+                                      << model_handle_ << "': " << e.what());
+  }
+}
+}  // namespace commands

--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -31,7 +31,7 @@ void ModelImportCmd::Exec() {
     std::filesystem::create_directories(
         std::filesystem::path(model_yaml_path).parent_path());
     gguf_handler.Parse(model_path_);
-    config::ModelConfig model_config = gguf_handler.GetModelConfig();
+    auto model_config = gguf_handler.GetModelConfig();
     model_config.files.push_back(model_path_);
     model_config.name = model_handle_;
     yaml_handler.UpdateModelConfig(model_config);
@@ -46,9 +46,8 @@ void ModelImportCmd::Exec() {
 
   } catch (const std::exception& e) {
     std::remove(model_yaml_path.c_str());
-    throw std::runtime_error("Error importing model '" + model_path_ +
-                             "' with model_id '" + model_handle_ +
-                             "': " + e.what());
+    CLI_LOG("Error importing model path '" + model_path_ + "' with model_id '" +
+            model_handle_ + "': " + e.what());
   }
 }
 }  // namespace commands

--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -33,7 +33,7 @@ void ModelImportCmd::Exec() {
     gguf_handler.Parse(model_path_);
     config::ModelConfig model_config = gguf_handler.GetModelConfig();
     model_config.files.push_back(model_path_);
-    model_config.name = model_handle_;
+    model_config.model = model_handle_;
     yaml_handler.UpdateModelConfig(model_config);
 
     if (modellist_utils_obj.AddModelEntry(model_entry)) {

--- a/engine/commands/model_import_cmd.h
+++ b/engine/commands/model_import_cmd.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cmath>  // For std::isnan
+#include <string>
+namespace commands {
+
+class ModelImportCmd {
+ public:
+  ModelImportCmd(std::string model_handle, std::string model_path);
+  void Exec();
+
+ private:
+  std::string model_handle_;
+  std::string model_path_;
+};
+}  // namespace commands

--- a/engine/commands/model_import_cmd.h
+++ b/engine/commands/model_import_cmd.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cmath>  // For std::isnan
 #include <string>
 namespace commands {
 

--- a/engine/controllers/command_line_parser.cc
+++ b/engine/controllers/command_line_parser.cc
@@ -158,11 +158,10 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
   auto model_import_cmd = models_cmd->add_subcommand(
       "import", "Import a gguf model from local file");
   model_import_cmd->add_option("--model_id", model_id, "");
-  model_import_cmd->require_option();
   model_import_cmd->add_option("--model_path", model_path,
                                "Absolute path to .gguf model, the path should "
                                "include the gguf file name");
-  model_import_cmd->require_option();
+  model_import_cmd->require_option(2);
   model_import_cmd->callback([&model_id,&model_path]() {
     commands::ModelImportCmd command(model_id, model_path);
     command.Exec();

--- a/engine/controllers/command_line_parser.cc
+++ b/engine/controllers/command_line_parser.cc
@@ -8,6 +8,7 @@
 #include "commands/engine_uninstall_cmd.h"
 #include "commands/model_del_cmd.h"
 #include "commands/model_get_cmd.h"
+#include "commands/model_import_cmd.h"
 #include "commands/model_list_cmd.h"
 #include "commands/model_pull_cmd.h"
 #include "commands/model_start_cmd.h"
@@ -155,6 +156,20 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
   auto model_update_cmd =
       models_cmd->add_subcommand("update", "Update configuration of a model");
 
+  std::string model_path;
+  auto model_import_cmd = models_cmd->add_subcommand(
+      "import", "Import a gguf model from local file");
+  model_import_cmd->add_option("--model_id", model_id, "");
+  model_import_cmd->require_option();
+  model_import_cmd->add_option("--model_path", model_path,
+                               "Absolute path to .gguf model, the path should "
+                               "include the gguf file name");
+  model_import_cmd->require_option();
+  model_import_cmd->callback([&model_id,&model_path]() {
+    commands::ModelImportCmd command(model_id, model_path);
+    command.Exec();
+  });
+
   // Default version is latest
   std::string version{"latest"};
   // engines group commands
@@ -238,7 +253,7 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
   auto ps_cmd =
       app_.add_subcommand("ps", "Show running models and their status");
   ps_cmd->group(kSystemGroup);
-  
+
   CLI11_PARSE(app_, argc, argv);
   if (argc == 1) {
     CLI_LOG(app_.help());

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -250,7 +250,7 @@ void Models::ImportModel(
 
   } catch (const std::exception& e) {
     std::remove(model_yaml_path.c_str());
-    std::string error_message = "Error importing model '" + modelPath +
+    std::string error_message = "Error importing model path '" + modelPath +
                                 "' with model_id '" + modelHandle +
                                 "': " + e.what();
     LOG_ERROR << error_message;

--- a/engine/controllers/models.h
+++ b/engine/controllers/models.h
@@ -15,6 +15,7 @@ class Models : public drogon::HttpController<Models> {
   METHOD_ADD(Models::PullModel, "/pull", Post);
   METHOD_ADD(Models::ListModel, "/list", Get);
   METHOD_ADD(Models::GetModel, "/get", Post);
+  METHOD_ADD(Models::ImportModel, "/import", Post);
   METHOD_ADD(Models::DeleteModel, "/{1}", Delete);
   METHOD_LIST_END
 
@@ -23,6 +24,8 @@ class Models : public drogon::HttpController<Models> {
   void ListModel(const HttpRequestPtr& req,
                  std::function<void(const HttpResponsePtr&)>&& callback) const;
   void GetModel(const HttpRequestPtr& req,
+                std::function<void(const HttpResponsePtr&)>&& callback) const;
+  void ImportModel(const HttpRequestPtr& req,
                 std::function<void(const HttpResponsePtr&)>&& callback) const;
   void DeleteModel(const HttpRequestPtr& req,
                    std::function<void(const HttpResponsePtr&)>&& callback,

--- a/engine/e2e-test/main.py
+++ b/engine/e2e-test/main.py
@@ -9,6 +9,7 @@ from test_cli_model_pull_direct_url import TestCliModelPullDirectUrl
 from test_cli_server_start import TestCliServerStart
 from test_cortex_update import TestCortexUpdate
 from test_create_log_folder import TestCreateLogFolder
+from test_cli_model_import import TestCliModelImport
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/engine/e2e-test/test_cli_model_import.py
+++ b/engine/e2e-test/test_cli_model_import.py
@@ -1,0 +1,14 @@
+import pytest
+from test_runner import run
+
+class TestCliModelImport:
+
+    @pytest.mark.skipif(True, reason="Expensive test. Only test when you have local gguf file.")
+    def test_model_import_should_be_success(self):
+
+        exit_code, output, error = run(
+            "Pull model", ["models", "import", "--model_id","test_model","--model_path","/path/to/local/gguf"],
+            timeout=None
+        )
+        assert exit_code == 0, f"Model import failed failed with error: {error}"
+        # TODO: skip this test. since download model is taking too long


### PR DESCRIPTION
## Related Issues

Fix #1249 

# Add Model Import Command to CLI

This PR introduces a new `import` subcommand to the `models` command in our CLI application. The new functionality allows users to import GGUF (GPT-Generated Unified Format) models from local files into the application.

## Features

- Import GGUF models using a specified model ID and file path
- Automatically parse GGUF files to extract model configuration
- Generate and store YAML configuration files for imported models
- Add imported models to the model list for easy management

## Implementation Details

The implementation consists of two main parts:

1. `ModelImportCmd` class in `model_import_cmd.h` and `model_import_cmd.cpp`
2. CLI11 command setup in the main application file

### ModelImportCmd

This class handles the core logic of importing a model:

- Parses the GGUF file using `GGUFHandler`
- Creates a `ModelConfig` object with the parsed information
- Generates a YAML configuration file using `YamlHandler`
- Adds the model entry to the model list using `ModelListUtils`

Error handling is implemented to ensure robust operation, including cleaning up partially created files in case of failures.

### CLI Setup

The `import` subcommand is added to the `models` command with the following options:

- `--model_id`: A required option to specify the unique identifier for the imported model
- `--model_path`: A required option to specify the absolute path to the GGUF model file

## Usage

To import a model, users can now use the following command:

```
./cortex models import --model_id <unique_model_id> --model_path /path/to/your/model.gguf
```
