### PR TITLE
fix: e2e failed test when download model with selection

### DIFF
--- a/engine/e2e-test/test_cli_model_delete.py
+++ b/engine/e2e-test/test_cli_model_delete.py
@@ -1,5 +1,5 @@
 import pytest
-from test_runner import run
+from test_runner import popen, run
 
 
 class TestCliModelDelete:
@@ -8,7 +8,7 @@ class TestCliModelDelete:
     def setup_and_teardown(self):
         # Setup
         # Pull model
-        run("Pull Model", ["pull", "tinyllama"], 120)
+        stdout, stderr, return_code = popen(["pull", "tinyllama"], "1\n")
 
         yield
 


### PR DESCRIPTION
## Describe Your Changes

- Fix a test case that relied on downloading model first, but download model now print out selection for variant and a variant need to be chosen to be continued download.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed