### PR TITLE
fix: correct permissions owner and group

### DIFF
--- a/engine/commands/cortex_upd_cmd.h
+++ b/engine/commands/cortex_upd_cmd.h
@@ -164,7 +164,15 @@ inline bool ReplaceBinaryInflight(const std::filesystem::path& src,
 
     // Set owner and group of the executable file
     if (chown(dst.string().c_str(), dst_file_owner, dst_file_group) != 0) {
-      CTL_ERR("Error setting owner and group of executable file: " << dst.string());
+      CTL_ERR(
+          "Error setting owner and group of executable file: " << dst.string());
+      restore_binary();
+      return false;
+    }
+    
+    // Remove cortex_temp
+    if (unlink(temp.string().c_str()) != 0) {
+      CTL_ERR("Error deleting self: " << strerror(errno));
       restore_binary();
       return false;
     }

--- a/engine/commands/cortex_upd_cmd.h
+++ b/engine/commands/cortex_upd_cmd.h
@@ -1,5 +1,9 @@
 #pragma once
 #include <string>
+#if defined(__linux__)
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 #include "httplib.h"
 #include "nlohmann/json.hpp"
@@ -15,6 +19,14 @@ constexpr const auto kNightlyFileName = "cortex-nightly.tar.gz";
 const std::string kCortexBinary = "cortex";
 constexpr const auto kBetaComp = "-rc";
 constexpr const auto kReleaseFormat = ".tar.gz";
+
+inline std::string GetRole() {
+#if defined(_WIN32)
+  return "";
+#else
+  return "sudo ";
+#endif
+}
 
 inline std::string GetCortexBinary() {
 #if defined(_WIN32)
@@ -88,7 +100,8 @@ inline void CheckNewUpdate() {
         if (current_version != latest_version) {
           CLI_LOG("\nA new release of cortex is available: "
                   << current_version << " -> " << latest_version);
-          CLI_LOG("To upgrade, run: " << GetCortexBinary() << " update");
+          CLI_LOG("To upgrade, run: " << GetRole() << GetCortexBinary()
+                                      << " update");
           if (CORTEX_VARIANT == file_manager_utils::kProdVariant) {
             CLI_LOG(json_res["html_url"].get<std::string>());
           }
@@ -113,25 +126,52 @@ inline bool ReplaceBinaryInflight(const std::filesystem::path& src,
   }
 
   std::filesystem::path temp = dst.parent_path() / "cortex_temp";
+  auto restore_binary = [&temp, &dst]() {
+    if (std::filesystem::exists(temp)) {
+      std::rename(temp.string().c_str(), dst.string().c_str());
+      CLI_LOG("Restored binary file");
+    }
+  };
 
   try {
     if (std::filesystem::exists(temp)) {
       std::filesystem::remove(temp);
     }
+#if defined(__linux__)
+    // Get permissions of the executable file
+    struct stat dst_file_stat;
+    if (stat(dst.string().c_str(), &dst_file_stat) != 0) {
+      CTL_ERR("Error getting permissions of executable file: " << dst.string());
+      return false;
+    }
+
+    // Get owner and group of the executable file
+    uid_t dst_file_owner = dst_file_stat.st_uid;
+    gid_t dst_file_group = dst_file_stat.st_gid;
+#endif
 
     std::rename(dst.string().c_str(), temp.string().c_str());
     std::filesystem::copy_file(
         src, dst, std::filesystem::copy_options::overwrite_existing);
-    std::filesystem::permissions(dst, std::filesystem::perms::owner_all |
-                                          std::filesystem::perms::group_all |
-                                          std::filesystem::perms::others_read |
-                                          std::filesystem::perms::others_exec);
+
+#if defined(__linux__)
+    // Set permissions of the executable file
+    if (chmod(dst.string().c_str(), dst_file_stat.st_mode) != 0) {
+      CTL_ERR("Error setting permissions of executable file: " << dst.string());
+      restore_binary();
+      return false;
+    }
+
+    // Set owner and group of the executable file
+    if (chown(dst.string().c_str(), dst_file_owner, dst_file_group) != 0) {
+      CTL_ERR("Error setting owner and group of executable file: " << dst.string());
+      restore_binary();
+      return false;
+    }
+#endif
   } catch (const std::exception& e) {
     CTL_ERR("Something went wrong: " << e.what());
-    if (std::filesystem::exists(temp)) {
-      std::rename(temp.string().c_str(), dst.string().c_str());
-      CLI_LOG("Restored binary file");
-    }
+    restore_binary();
     return false;
   }
 

--- a/engine/commands/cortex_upd_cmd.h
+++ b/engine/commands/cortex_upd_cmd.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#if defined(__linux__)
+#if !defined(_WIN32)
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -137,7 +137,7 @@ inline bool ReplaceBinaryInflight(const std::filesystem::path& src,
     if (std::filesystem::exists(temp)) {
       std::filesystem::remove(temp);
     }
-#if defined(__linux__)
+#if !defined(_WIN32)
     // Get permissions of the executable file
     struct stat dst_file_stat;
     if (stat(dst.string().c_str(), &dst_file_stat) != 0) {
@@ -154,7 +154,7 @@ inline bool ReplaceBinaryInflight(const std::filesystem::path& src,
     std::filesystem::copy_file(
         src, dst, std::filesystem::copy_options::overwrite_existing);
 
-#if defined(__linux__)
+#if !defined(_WIN32)
     // Set permissions of the executable file
     if (chmod(dst.string().c_str(), dst_file_stat.st_mode) != 0) {
       CTL_ERR("Error setting permissions of executable file: " << dst.string());
@@ -169,7 +169,7 @@ inline bool ReplaceBinaryInflight(const std::filesystem::path& src,
       restore_binary();
       return false;
     }
-    
+
     // Remove cortex_temp
     if (unlink(temp.string().c_str()) != 0) {
       CTL_ERR("Error deleting self: " << strerror(errno));

--- a/engine/test/components/test_cortex_upd_cmd.cc
+++ b/engine/test/components/test_cortex_upd_cmd.cc
@@ -43,7 +43,11 @@ TEST_F(CortexUpdCmdTest, replace_binary_successfully) {
   std::filesystem::path new_binary(kNewReleaseFile);
   std::filesystem::path cur_binary(kCurReleaseFile);
   EXPECT_TRUE(commands::ReplaceBinaryInflight(new_binary, cur_binary));
+#if defined(__linux__)
+  EXPECT_FALSE(std::filesystem::exists(kCortexTemp));
+#else
   EXPECT_TRUE(std::filesystem::exists(kCortexTemp));
+#endif
 }
 
 TEST_F(CortexUpdCmdTest, should_restore_old_binary_if_has_error) {

--- a/engine/test/components/test_cortex_upd_cmd.cc
+++ b/engine/test/components/test_cortex_upd_cmd.cc
@@ -54,8 +54,6 @@ TEST_F(CortexUpdCmdTest, replace_binary_successfully) {
 
   struct stat new_file_stat;
   EXPECT_TRUE(stat(cur_binary.string().c_str(), &new_file_stat) == 0);
-  uid_t new_file_owner = new_file_stat.st_uid;
-  gid_t new_file_group = new_file_stat.st_gid;
   EXPECT_EQ(cur_file_stat.st_uid, new_file_stat.st_uid);
   EXPECT_EQ(cur_file_stat.st_gid, new_file_stat.st_gid);
   EXPECT_EQ(cur_file_stat.st_mode, new_file_stat.st_mode);

--- a/engine/test/components/test_cortex_upd_cmd.cc
+++ b/engine/test/components/test_cortex_upd_cmd.cc
@@ -43,7 +43,7 @@ TEST_F(CortexUpdCmdTest, replace_binary_successfully) {
   std::filesystem::path new_binary(kNewReleaseFile);
   std::filesystem::path cur_binary(kCurReleaseFile);
   EXPECT_TRUE(commands::ReplaceBinaryInflight(new_binary, cur_binary));
-#if defined(__linux__)
+#if !defined(_WIN32)
   EXPECT_FALSE(std::filesystem::exists(kCortexTemp));
 #else
   EXPECT_TRUE(std::filesystem::exists(kCortexTemp));

--- a/engine/test/components/test_cortex_upd_cmd.cc
+++ b/engine/test/components/test_cortex_upd_cmd.cc
@@ -42,9 +42,23 @@ TEST_F(CortexUpdCmdTest, return_true_if_self_replace) {
 TEST_F(CortexUpdCmdTest, replace_binary_successfully) {
   std::filesystem::path new_binary(kNewReleaseFile);
   std::filesystem::path cur_binary(kCurReleaseFile);
+#if !defined(_WIN32)
+  struct stat cur_file_stat;
+  EXPECT_TRUE(stat(cur_binary.string().c_str(), &cur_file_stat) == 0);
+#endif
+
   EXPECT_TRUE(commands::ReplaceBinaryInflight(new_binary, cur_binary));
+
 #if !defined(_WIN32)
   EXPECT_FALSE(std::filesystem::exists(kCortexTemp));
+
+  struct stat new_file_stat;
+  EXPECT_TRUE(stat(cur_binary.string().c_str(), &new_file_stat) == 0);
+  uid_t new_file_owner = new_file_stat.st_uid;
+  gid_t new_file_group = new_file_stat.st_gid;
+  EXPECT_EQ(cur_file_stat.st_uid, new_file_stat.st_uid);
+  EXPECT_EQ(cur_file_stat.st_gid, new_file_stat.st_gid);
+  EXPECT_EQ(cur_file_stat.st_mode, new_file_stat.st_mode);
 #else
   EXPECT_TRUE(std::filesystem::exists(kCortexTemp));
 #endif


### PR DESCRIPTION
## Describe Your Changes

- The updater works on Windows but not on Linux and macOS due to owner and group. This PR fixes the issue by copying the permissions, owner, and group of the old executable binary.
- Also add the `sudo cortex update` message for Linux and macOS.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1257

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed