### PR TITLE
fix: flush chat content to for each response data

### DIFF
--- a/engine/commands/chat_cmd.cc
+++ b/engine/commands/chat_cmd.cc
@@ -115,7 +115,7 @@ void ChatCmd::Exec(std::string msg) {
             std::cout << std::endl;
             return false;
           }
-          std::cout << cp.content;
+          std::cout << cp.content << std::flush;
           ai_chat += cp.content;
           return true;
         };


### PR DESCRIPTION
## Describe Your Changes

std::cout only flush when buffer is full. Should flush for each message we receive for better UX.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed