### PR TITLE
feat: add download resume

### DIFF
--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -1,14 +1,15 @@
+#include "download_service.h"
 #include <curl/curl.h>
 #include <httplib.h>
 #include <stdio.h>
 #include <trantor/utils/Logger.h>
 #include <filesystem>
+#include <ostream>
 #include <thread>
-
-#include "download_service.h"
 #include "exceptions/failed_curl_exception.h"
 #include "exceptions/failed_init_curl_exception.h"
 #include "exceptions/failed_open_file_exception.h"
+#include "utils/format_utils.h"
 #include "utils/logging_utils.h"
 
 namespace {
@@ -19,14 +20,15 @@ size_t WriteCallback(void* ptr, size_t size, size_t nmemb, FILE* stream) {
 }  // namespace
 
 void DownloadService::AddDownloadTask(
-    const DownloadTask& task,
-    std::optional<OnDownloadTaskSuccessfully> callback) {
+    DownloadTask& task, std::optional<OnDownloadTaskSuccessfully> callback) {
   CLI_LOG("Validating download items, please wait..");
   // preprocess to check if all the item are valid
   auto total_download_size{0};
-  for (const auto& item : task.items) {
+  for (auto& item : task.items) {
     try {
-      total_download_size += GetFileSize(item.downloadUrl);
+      auto size = GetFileSize(item.downloadUrl);
+      item.bytes = size;
+      total_download_size += size;
     } catch (const FailedCurlException& e) {
       CTL_ERR("Found invalid download item: " << item.downloadUrl << " - "
                                               << e.what());
@@ -37,7 +39,7 @@ void DownloadService::AddDownloadTask(
   // all items are valid, start downloading
   for (const auto& item : task.items) {
     CLI_LOG("Start downloading: " + item.localPath.filename().string());
-    Download(task.id, item);
+    Download(task.id, item, true);
   }
 
   if (callback.has_value()) {
@@ -76,7 +78,7 @@ void DownloadService::AddAsyncDownloadTask(
 
   for (const auto& item : task.items) {
     std::thread([this, task, &callback, item]() {
-      this->Download(task.id, item);
+      this->Download(task.id, item, false);
     }).detach();
   }
 
@@ -84,7 +86,8 @@ void DownloadService::AddAsyncDownloadTask(
 }
 
 void DownloadService::Download(const std::string& download_id,
-                               const DownloadItem& download_item) {
+                               const DownloadItem& download_item,
+                               bool allow_resume) {
   CTL_INF("Absolute file output: " << download_item.localPath.string());
 
   CURL* curl;
@@ -96,7 +99,43 @@ void DownloadService::Download(const std::string& download_id,
     throw FailedInitCurlException();
   }
 
-  file = fopen(download_item.localPath.string().c_str(), "wb");
+  std::string mode = "wb";
+  if (allow_resume && std::filesystem::exists(download_item.localPath) &&
+      download_item.bytes.has_value()) {
+    FILE* existing_file = fopen(download_item.localPath.string().c_str(), "r");
+    fseek(existing_file, 0, SEEK_END);
+    curl_off_t existing_file_size = ftell(existing_file);
+    fclose(existing_file);
+    auto missing_bytes = download_item.bytes.value() - existing_file_size;
+    if (missing_bytes > 0) {
+      CLI_LOG("Found unfinished download! Additional "
+              << format_utils::BytesToHumanReadable(missing_bytes)
+              << " need to be downloaded.");
+      std::cout << "Continue download [Y/n]: " << std::flush;
+      std::string answer{""};
+      std::cin >> answer;
+      if (answer == "Y" || answer == "y" || answer.empty()) {
+        mode = "ab";
+        CLI_LOG("Resuming download..");
+      } else {
+        CLI_LOG("Start over..");
+      }
+    } else {
+      CLI_LOG(download_item.localPath.filename().string()
+              << " is already downloaded!");
+      std::cout << "Re-download? [Y/n]: " << std::flush;
+
+      std::string answer = "";
+      std::cin >> answer;
+      if (answer == "Y" || answer == "y" || answer.empty()) {
+        CLI_LOG("Re-downloading..");
+      } else {
+        return;
+      }
+    }
+  }
+
+  file = fopen(download_item.localPath.string().c_str(), mode.c_str());
   if (!file) {
     auto err_msg{"Failed to open output file " +
                  download_item.localPath.string()};
@@ -108,6 +147,12 @@ void DownloadService::Download(const std::string& download_id,
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, file);
   curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+  if (mode == "ab") {
+    fseek(file, 0, SEEK_END);
+    curl_off_t local_file_size = ftell(file);
+    curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, local_file_size);
+  }
 
   res = curl_easy_perform(curl);
 

--- a/engine/services/download_service.h
+++ b/engine/services/download_service.h
@@ -20,6 +20,8 @@ struct DownloadItem {
 
   std::optional<std::string> checksum;
 
+  std::optional<uint64_t> bytes;
+
   std::string ToString() const {
     std::ostringstream output;
     output << "DownloadItem{id: " << id << ", downloadUrl: " << downloadUrl
@@ -54,7 +56,7 @@ class DownloadService {
       std::function<void(const DownloadTask& task)>;
 
   void AddDownloadTask(
-      const DownloadTask& task,
+      DownloadTask& task,
       std::optional<OnDownloadTaskSuccessfully> callback = std::nullopt);
 
   void AddAsyncDownloadTask(
@@ -70,5 +72,5 @@ class DownloadService {
 
  private:
   void Download(const std::string& download_id,
-                const DownloadItem& download_item);
+                const DownloadItem& download_item, bool allow_resume);
 };


### PR DESCRIPTION
## Describe Your Changes

- Add download resume functionality.

## Screenshots
1. If cortex found that the file haven't fully downloaded, will ask if user want to continue (resume)
<img width="871" alt="Screenshot 2024-09-20 at 14 21 35" src="https://github.com/user-attachments/assets/ac91b139-0a36-4f24-941e-3bed7aa61c2c">

2. If file is already downloaded, will ask if user want to redownload or ignore
<img width="766" alt="Screenshot 2024-09-20 at 14 23 10" src="https://github.com/user-attachments/assets/664a2909-4b24-401a-a4ba-074eba035a2a">

## Fixes Issues

- #777 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed