### PR TITLE
Fix: add try catch when parsing streaming result from server

### DIFF
--- a/engine/commands/chat_cmd.cc
+++ b/engine/commands/chat_cmd.cc
@@ -26,7 +26,11 @@ struct ChunkParser {
       if (s.find("[DONE]") != std::string::npos) {
         is_done = true;
       } else {
-        content = nlohmann::json::parse(s)["choices"][0]["delta"]["content"];
+        try {
+          content = nlohmann::json::parse(s)["choices"][0]["delta"]["content"];
+        } catch (const nlohmann::json::parse_error& e) {
+          CTL_WRN("JSON parse error: " << e.what());
+        }
       }
     }
   }


### PR DESCRIPTION
Fix #1273


> ## Problem 1
> 
> 1. `cortex pull llama3.1-url` , download is successful
> 2. `cortex run llama3.1`
> 3. Get interactive shell
> 4. Send "hi"
> 5. Get error
> 
> ```sh
> ❯ cortex-nightly run llama3.1
> 
> Inorder to exit, type `exit()`
> 
> > hi
> 
> libc++abi: terminating due to uncaught exception of type nlohmann::json_abi_v3_11_3::detail::parse_error: [json.exception.parse_error.101] parse error at line 3, column 1: syntax error while parsing value - invalid literal; last read: '"chat.completion.chunk"}<U+000A><U+000A>d'; expected end of input
> 
> 5![1]    93403 abort      cortex-nightly run llama3.1
> ```
> 
> This happened a few times
> 

This problem due to `nlohmann::json` fail to parse content result from engine, this bug happened randomly. For that reason, we will add an `try/catch` logic to avoid this bug to crash the program and investigate easier.
This bug also appeared in Linux rarely and very hard to reproduce.