### PR TITLE
fix: correct minimum required cuda version for llamacpp

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -224,7 +224,7 @@ void EngineService::InstallEngine(const std::string& engine,
           if (cuda_driver_semver.major == 11) {
             suitable_toolkit_version = "11.7";
           } else if (cuda_driver_semver.major == 12) {
-            suitable_toolkit_version = "12.4";
+            suitable_toolkit_version = "12.0";
           }
         }
 


### PR DESCRIPTION
## Describe Your Changes

https://github.com/janhq/cortex/issues/1046 still in-progress, so we need to specify the minimum required Cuda version for engines. 
Change from `12.4` to `12.0` to make our `dev` branch works correctly.

## Fixes Issues

- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed