### PR TITLE
Fix permission macos installer

### DIFF
--- a/engine/templates/macos/create_pkg.sh
+++ b/engine/templates/macos/create_pkg.sh
@@ -14,6 +14,8 @@ cp $SOURCE_BINARY_PATH installer/$DESTINATION_BINARY_NAME
 export DESTINATION_BINARY_NAME
 cp postinstall Scripts/postinstall
 sed -i '' "3s/.*/DESTINATION_BINARY_NAME=$DESTINATION_BINARY_NAME/" Scripts/postinstall
+sed -i '' "4s/.*/DATA_FOLDER_NAME=$DATA_FOLDER_NAME/" Scripts/postinstall
+sed -i '' "5s/.*/CONFIGURATION_FILE_NAME=$CONFIGURATION_FILE_NAME/" Scripts/postinstall
 chmod +x Scripts/postinstall
 
 export DATA_FOLDER_NAME CONFIGURATION_FILE_NAME UNINSTALLER_FILE_NAME

--- a/engine/templates/macos/postinstall
+++ b/engine/templates/macos/postinstall
@@ -1,8 +1,15 @@
 #!/usr/bin/env sh
 set -e
 DESTINATION_BINARY_NAME=cortex
-USER_TO_RUN_AS=${SUDO_USER:-$(whoami)}
-echo "Download cortex.llamacpp engines by default"
+DATA_FOLDER_NAME=.cortex
+CONFIGURATION_FILE_NAME=.cortexrc
+
+USER_TO_RUN_AS=$(stat -f "%Su" /dev/console)
+
+echo "Download cortex.llamacpp engines by default for user $USER_TO_RUN_AS"
 sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME engines install cortex.llamacpp
+
+sudo chown -R $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME"
+sudo chown $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME"
 
 exit 0


### PR DESCRIPTION
## Describe Your Changes

- Fix permission macos installer

The current file permissions assign ownership to root. <img width="482" alt="image" src="https://github.com/user-attachments/assets/effbca3e-71aa-47ad-b36d-8c2a69602741">

This PR will adjust the permissions, assigning ownership to the current user instead of root for the cortexcpp folder. <img width="415" alt="image" src="https://github.com/user-attachments/assets/0dfc601f-64a8-48e2-8f60-2c4e529114e9">


## Fixes Issues

- Closes #1274 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed