### PR TITLE
fix: cortex chat is a non-interactive request

### DIFF
--- a/engine/commands/chat_cmd.cc
+++ b/engine/commands/chat_cmd.cc
@@ -71,14 +71,19 @@ void ChatCmd::Exec(const std::string& host, int port,
     return;
   }
 
+  // Interactive mode or not
+  bool interactive = msg.empty();
+
   // Some instruction for user here
-  std::cout << "Inorder to exit, type `exit()`" << std::endl;
+  if (interactive) {
+    std::cout << "Inorder to exit, type `exit()`" << std::endl;
+  }
   // Model is loaded, start to chat
   {
-    while (true) {
+    do {
       std::string user_input = std::move(msg);
-      std::cout << "> ";
       if (user_input.empty()) {
+        std::cout << "> ";
         std::getline(std::cin, user_input);
       }
       if (user_input == kExitChat) {
@@ -128,7 +133,7 @@ void ChatCmd::Exec(const std::string& host, int port,
         histories_.push_back(std::move(ai_res));
       }
       // std::cout << "ok Done" << std::endl;
-    }
+    } while (interactive);
   }
 }
 

--- a/engine/controllers/command_line_parser.cc
+++ b/engine/controllers/command_line_parser.cc
@@ -122,20 +122,20 @@ void CommandLineParser::SetupCommonCommands() {
   auto chat_cmd = app_.add_subcommand("chat", "Send a chat completion request");
   chat_cmd->group(kCommonCommandsGroup);
   chat_cmd->usage("Usage:\n" + commands::GetCortexBinary() +
-                  " chat [model_id] [options]");
+                  " chat [model_id] -m [msg]");
   chat_cmd->add_option("model_id", cml_data_.model_id, "");
   chat_cmd->add_option("-m,--message", cml_data_.msg,
                        "Message to chat with model");
   chat_cmd->callback([this, chat_cmd] {
-    if (cml_data_.model_id.empty()) {
-      CLI_LOG("[model_id] is required\n");
+    if (cml_data_.model_id.empty() || cml_data_.msg.empty()) {
+      CLI_LOG("[model_id] and [msg] are required\n");
       CLI_LOG(chat_cmd->help());
       return;
     }
 
     commands::ChatCmd().Exec(cml_data_.config.apiServerHost,
-            std::stoi(cml_data_.config.apiServerPort), cml_data_.model_id,
-            cml_data_.msg);
+                             std::stoi(cml_data_.config.apiServerPort),
+                             cml_data_.model_id, cml_data_.msg);
   });
 }
 


### PR DESCRIPTION
## Describe Your Changes
`-m, --message` is now required for `cortex chat`
```
> .\cortex-nightly.exe chat tinyllama:gguf
[model_id] and [msg] are required

Send a chat completion request
Usage:
cortex-nightly.exe chat [model_id] -m [msg]

Positionals:
  model_id TEXT

Options:
  -h,--help                   Print this help message and exit
  -m,--message TEXT           Message to chat with model
```

Examples:
```
> .\cortex-nightly.exe chat tinyllama:gguf -m "Tell me a joke"
Sure, here's a funny one for you:

A man goes to the doctor with a cough. The doctor suggests medication and prescribes a pill that will make him cough up his gold teeth.

The man is thrilled at this newfound freedom from the nuisance of dental hygiene, but as he takes the pill, he realizes it's not a solution at all. It only makes his 
teeth twist and turn in unnatural ways.

Without thinking, the man throws away the pill and heads to the bathroom where he proceeds to mangle his own teeth, causing a chain of events that leads him to lose control and scream "Umbrella! UM-BREAKING!"

The joke ends with the doctor running outside in the rain to find their umbrella has fallen apart, and the man is left as an object of ridicule, surrounded by broken 
teeth.

Hope you're having a great time with this one!
```
## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1313

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed