### PR TITLE
fix: create config file if does not exist before getting data path

### DIFF
--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -168,9 +168,7 @@ inline config_yaml_utils::CortexConfig GetCortexConfig() {
 }
 
 inline std::filesystem::path GetCortexDataPath() {
-  // TODO: We will need to support user to move the data folder to other place.
-  // TODO: get the variant of cortex. As discussed, we will have: prod, beta, nightly
-  // currently we will store cortex data at ~/cortexcpp
+  CreateConfigFileIfNotExist();
   auto config = GetCortexConfig();
   std::filesystem::path data_folder_path;
   if (!config.dataFolderPath.empty()) {


### PR DESCRIPTION
## Describe Your Changes

- Current db implementation needs to get data path before main setup. So create config file if it does not exist.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed