### PR TITLE
fix: work around for connection hang when network down

### DIFF
--- a/engine/controllers/command_line_parser.cc
+++ b/engine/controllers/command_line_parser.cc
@@ -73,7 +73,7 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
 #ifdef CORTEX_CPP_VERSION
   if (cml_data_.check_upd) {
     // TODO(sang) find a better way to handle
-    // This is a extremely ungly way to deal with connection 
+    // This is an extremely ungly way to deal with connection 
     // hang when network down
     std::atomic<bool> done = false;
     std::thread t([&]() {
@@ -90,9 +90,9 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
     });
     // Do not wait for http connection timeout
     t.detach();
-    int retry = 5;
+    int retry = 10;
     while (!done && retry--) {
-      std::this_thread::sleep_for(commands::kTimeoutCheckUpdate / 5);
+      std::this_thread::sleep_for(commands::kTimeoutCheckUpdate / 10);
     }
   }
 #endif

--- a/engine/controllers/command_line_parser.cc
+++ b/engine/controllers/command_line_parser.cc
@@ -69,7 +69,7 @@ bool CommandLineParser::SetupCommand(int argc, char** argv) {
     return true;
   }
 
-  // Check new update, only check for stable release for now
+  // Check new update
 #ifdef CORTEX_CPP_VERSION
   if (cml_data_.check_upd) {
     // TODO(sang) find a better way to handle


### PR DESCRIPTION
## Describe Your Changes

When the network is down, our process is hang for 10 seconds to wait for HTTP response. The httplib does not support connection timeout in this case yet, so we need to work around.

## Fixes Issues

- Closes https://github.com/janhq/cortex.cpp/issues/1350

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed