### PR TITLE
fix: ignore SIGINT for server

### DIFF
--- a/engine/main.cc
+++ b/engine/main.cc
@@ -28,7 +28,15 @@
 #endif
 
 void RunServer() {
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
   signal(SIGINT, SIG_IGN);
+#elif defined(_WIN32)
+  auto console_ctrl_handler = +[](DWORD ctrl_type) -> BOOL {
+    return (ctrl_type == CTRL_C_EVENT) ? true : false;
+  };
+  SetConsoleCtrlHandler(
+      reinterpret_cast<PHANDLER_ROUTINE>(console_ctrl_handler), true);
+#endif
   auto config = file_manager_utils::GetCortexConfig();
   std::cout << "Host: " << config.apiServerHost
             << " Port: " << config.apiServerPort << "\n";
@@ -49,23 +57,8 @@ void RunServer() {
       [&]() { asyncFileLogger.flush(); });
   LOG_INFO << "Host: " << config.apiServerHost
            << " Port: " << config.apiServerPort << "\n";
-  // Number of cortex.cpp threads
-  // if (argc > 1) {
-  //   thread_num = std::atoi(argv[1]);
-  // }
 
-  // // Check for host argument
-  // if (argc > 2) {
-  //   host = argv[2];
-  // }
-
-  // // Check for port argument
-  // if (argc > 3) {
-  //   port = std::atoi(argv[3]);  // Convert string argument to int
-  // }
   int thread_num = 1;
-  // std::string host = "127.0.0.1";
-  // int port = 3928;
 
   int logical_cores = std::thread::hardware_concurrency();
   int drogon_thread_num = std::max(thread_num, logical_cores);

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -28,6 +28,7 @@
 #endif
 
 void RunServer() {
+  signal(SIGINT, SIG_IGN);
   auto config = file_manager_utils::GetCortexConfig();
   std::cout << "Host: " << config.apiServerHost
             << " Port: " << config.apiServerPort << "\n";
@@ -82,6 +83,7 @@ void RunServer() {
                             std::stoi(config.apiServerPort));
   drogon::app().setThreadNum(drogon_thread_num);
   LOG_INFO << "Number of thread is:" << drogon::app().getThreadNum();
+  drogon::app().disableSigtermHandling();
 
   drogon::app().run();
   // return 0;


### PR DESCRIPTION
## Describe Your Changes

`cortex chat` is working on interactive mode. If we send a `SIGINT`, the server will be terminated.
We should ignore `SIGINT` for server.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1187

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed