### PR TITLE
fix: correct model_id in chat

### DIFF
--- a/engine/commands/chat_completion_cmd.h
+++ b/engine/commands/chat_completion_cmd.h
@@ -9,8 +9,8 @@ class ChatCompletionCmd {
  public:
   void Exec(const std::string& host, int port, const std::string& model_handle,
             std::string msg);
-  void Exec(const std::string& host, int port, const config::ModelConfig& mc,
-            std::string msg);
+  void Exec(const std::string& host, int port, const std::string& model_handle,
+            const config::ModelConfig& mc, std::string msg);
 
  private:
   std::vector<nlohmann::json> histories_;

--- a/engine/commands/model_start_cmd.cc
+++ b/engine/commands/model_start_cmd.cc
@@ -5,6 +5,7 @@
 #include "model_status_cmd.h"
 #include "nlohmann/json.hpp"
 #include "server_start_cmd.h"
+#include "services/model_service.h"
 #include "trantor/utils/Logger.h"
 #include "utils/file_manager_utils.h"
 #include "utils/logging_utils.h"
@@ -12,77 +13,15 @@
 namespace commands {
 bool ModelStartCmd::Exec(const std::string& host, int port,
                          const std::string& model_handle) {
+  ModelService ms;
+  auto res = ms.StartModel(host, port, model_handle);
 
-  cortex::db::Models modellist_handler;
-  config::YamlHandler yaml_handler;
-  try {
-    auto model_entry = modellist_handler.GetModelInfo(model_handle);
-    if (model_entry.has_error()) {
-      CLI_LOG("Error: " + model_entry.error());
-      return false;
-    }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
-    auto mc = yaml_handler.GetModelConfig();
-    return Exec(host, port, mc);
-  } catch (const std::exception& e) {
-    CLI_LOG("Fail to start model information with ID '" + model_handle +
-            "': " + e.what());
+  if (res.has_error()) {
+    CLI_LOG("Error: " + res.error());
     return false;
   }
-}
-
-bool ModelStartCmd::Exec(const std::string& host, int port,
-                         const config::ModelConfig& mc) {
-  // Check if server is started
-  if (!commands::IsServerAlive(host, port)) {
-    CLI_LOG("Server is not started yet, please run `"
-            << commands::GetCortexBinary() << " start` to start server!");
-    return false;
-  }
-
-  // Only check for llamacpp for now
-  if ((mc.engine.find("llamacpp") != std::string::npos) &&
-      commands::ModelStatusCmd().IsLoaded(host, port, mc)) {
-    CLI_LOG("Model has already been started!");
-    return true;
-  }
-
-  httplib::Client cli(host + ":" + std::to_string(port));
-
-  nlohmann::json json_data;
-  if (mc.files.size() > 0) {
-    // TODO(sang) support multiple files
-    json_data["model_path"] = mc.files[0];
-  } else {
-    LOG_WARN << "model_path is empty";
-    return false;
-  }
-  json_data["model"] = mc.name;
-  json_data["system_prompt"] = mc.system_template;
-  json_data["user_prompt"] = mc.user_template;
-  json_data["ai_prompt"] = mc.ai_template;
-  json_data["ctx_len"] = mc.ctx_len;
-  json_data["stop"] = mc.stop;
-  json_data["engine"] = mc.engine;
-
-  auto data_str = json_data.dump();
-  cli.set_read_timeout(std::chrono::seconds(60));
-  auto res = cli.Post("/inferences/server/loadmodel", httplib::Headers(),
-                      data_str.data(), data_str.size(), "application/json");
-  if (res) {
-    if (res->status == httplib::StatusCode::OK_200) {
-      CLI_LOG("Model loaded!");
-      return true;
-    } else {
-      CTL_ERR("Model failed to load with status code: " << res->status);
-      return false;
-    }
-  } else {
-    auto err = res.error();
-    CTL_ERR("HTTP error: " << httplib::to_string(err));
-    return false;
-  }
-  return false;
+  CLI_LOG("Model loaded!");
+  return true;
 }
 
 };  // namespace commands

--- a/engine/commands/model_start_cmd.h
+++ b/engine/commands/model_start_cmd.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string>
-#include "config/model_config.h"
 
 namespace commands {
 
@@ -8,6 +7,5 @@ class ModelStartCmd {
  public:
   bool Exec(const std::string& host, int port, const std::string& model_handle);
 
-  bool Exec(const std::string& host, int port, const config::ModelConfig& mc);
 };
 }  // namespace commands

--- a/engine/commands/model_status_cmd.cc
+++ b/engine/commands/model_status_cmd.cc
@@ -4,49 +4,18 @@
 #include "httplib.h"
 #include "nlohmann/json.hpp"
 #include "utils/logging_utils.h"
+#include "services/model_service.h"
 
 namespace commands {
 bool ModelStatusCmd::IsLoaded(const std::string& host, int port,
                               const std::string& model_handle) {
-  cortex::db::Models modellist_handler;
-  config::YamlHandler yaml_handler;
-  try {
-    auto model_entry = modellist_handler.GetModelInfo(model_handle);
-    if (model_entry.has_error()) {
-      CLI_LOG("Error: " + model_entry.error());
-      return false;
-    }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
-    auto mc = yaml_handler.GetModelConfig();
-    return IsLoaded(host, port, mc);
-  } catch (const std::exception& e) {
-    CLI_LOG("Fail to get model status with ID '" + model_handle +
-            "': " + e.what());
+  ModelService ms;
+  auto res = ms.GetModelStatus(host, port, model_handle);
+
+  if (res.has_error()) {
+    // CLI_LOG("Error: " + res.error());
     return false;
   }
-}
-
-bool ModelStatusCmd::IsLoaded(const std::string& host, int port,
-                              const config::ModelConfig& mc) {
-  httplib::Client cli(host + ":" + std::to_string(port));
-  nlohmann::json json_data;
-  json_data["model"] = mc.name;
-  json_data["engine"] = mc.engine;
-
-  auto data_str = json_data.dump();
-
-  auto res = cli.Post("/inferences/server/modelstatus", httplib::Headers(),
-                      data_str.data(), data_str.size(), "application/json");
-  if (res) {
-    if (res->status == httplib::StatusCode::OK_200) {
-      return true;
-    }
-  } else {
-    auto err = res.error();
-    CTL_WRN("HTTP error: " << httplib::to_string(err));
-    return false;
-  }
-
-  return false;
+  return true;
 }
 }  // namespace commands

--- a/engine/commands/model_status_cmd.h
+++ b/engine/commands/model_status_cmd.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string>
-#include "config/yaml_config.h"
 
 namespace commands {
 
@@ -8,7 +7,5 @@ class ModelStatusCmd {
  public:
   bool IsLoaded(const std::string& host, int port,
                 const std::string& model_handle);
-  bool IsLoaded(const std::string& host, int port,
-                const config::ModelConfig& mc);
 };
 }  // namespace commands

--- a/engine/commands/model_stop_cmd.cc
+++ b/engine/commands/model_stop_cmd.cc
@@ -5,45 +5,20 @@
 #include "nlohmann/json.hpp"
 #include "utils/file_manager_utils.h"
 #include "utils/logging_utils.h"
+#include "services/model_service.h"
 
 namespace commands {
 
 void ModelStopCmd::Exec(const std::string& host, int port,
                         const std::string& model_handle) {
-  cortex::db::Models modellist_handler;
-  config::YamlHandler yaml_handler;
-  try {
-    auto model_entry = modellist_handler.GetModelInfo(model_handle);
-    if (model_entry.has_error()) {
-      CLI_LOG("Error: " + model_entry.error());
-      return;
-    }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
-    auto mc = yaml_handler.GetModelConfig();
-    httplib::Client cli(host + ":" + std::to_string(port));
-    nlohmann::json json_data;
-    json_data["model"] = mc.name;
-    json_data["engine"] = mc.engine;
+  ModelService ms;
+  auto res = ms.StopModel(host, port, model_handle);
 
-    auto data_str = json_data.dump();
-
-    auto res = cli.Post("/inferences/server/unloadmodel", httplib::Headers(),
-                        data_str.data(), data_str.size(), "application/json");
-    if (res) {
-      if (res->status == httplib::StatusCode::OK_200) {
-        // LOG_INFO << res->body;
-        CLI_LOG("Model unloaded!");
-      } else {
-        CLI_LOG("Error: could not unload model - " << res->status);
-      }
-    } else {
-      auto err = res.error();
-      CTL_ERR("HTTP error: " << httplib::to_string(err));
-    }
-  } catch (const std::exception& e) {
-    CLI_LOG("Fail to stop model information with ID '" + model_handle +
-            "': " + e.what());
+  if (res.has_error()) {
+    CLI_LOG("Error: " + res.error());
+    return;
   }
+  CLI_LOG("Model unloaded!");
 }
 
 };  // namespace commands

--- a/engine/commands/run_cmd.cc
+++ b/engine/commands/run_cmd.cc
@@ -72,8 +72,8 @@ void RunCmd::Exec(bool chat_flag) {
     // If it is llamacpp, then check model status first
     {
       if ((mc.engine.find("llamacpp") == std::string::npos) ||
-          !commands::ModelStatusCmd().IsLoaded(host_, port_, mc)) {
-        if (!ModelStartCmd().Exec(host_, port_, mc)) {
+          !commands::ModelStatusCmd().IsLoaded(host_, port_, model_handle_)) {
+        if (!ModelStartCmd().Exec(host_, port_, model_handle_)) {
           return;
         }
       }
@@ -81,7 +81,7 @@ void RunCmd::Exec(bool chat_flag) {
 
     // Chat
     if (chat_flag) {
-      ChatCompletionCmd().Exec(host_, port_, mc, "");
+      ChatCompletionCmd().Exec(host_, port_, model_handle_, mc, "");
     } else {
       CLI_LOG(*model_id << " model started successfully. Use `"
                         << commands::GetCortexBinary() << " chat " << *model_id

--- a/engine/controllers/models.h
+++ b/engine/controllers/models.h
@@ -18,6 +18,8 @@ class Models : public drogon::HttpController<Models> {
   METHOD_ADD(Models::ImportModel, "/import", Post);
   METHOD_ADD(Models::DeleteModel, "/{1}", Delete);
   METHOD_ADD(Models::SetModelAlias, "/alias", Post);
+  METHOD_ADD(Models::StartModel, "/start", Post);
+  METHOD_ADD(Models::StopModel, "/stop", Post);
   METHOD_LIST_END
 
   void PullModel(const HttpRequestPtr& req,
@@ -38,6 +40,12 @@ class Models : public drogon::HttpController<Models> {
   void SetModelAlias(
       const HttpRequestPtr& req,
       std::function<void(const HttpResponsePtr&)>&& callback) const;
+
+  void StartModel(const HttpRequestPtr& req,
+                  std::function<void(const HttpResponsePtr&)>&& callback);
+
+  void StopModel(const HttpRequestPtr& req,
+                 std::function<void(const HttpResponsePtr&)>&& callback);
 
  private:
   ModelService model_service_;

--- a/engine/controllers/server.h
+++ b/engine/controllers/server.h
@@ -107,6 +107,8 @@ class server : public drogon::HttpController<server>,
                      std::function<void(const HttpResponsePtr&)>& callback,
                      const std::string& field);
 
+  bool HasFieldInReq(const HttpRequestPtr& req, const std::string& field);
+
  private:
   struct SyncQueue {
     void push(std::pair<Json::Value, Json::Value>&& p) {

--- a/engine/services/model_service.h
+++ b/engine/services/model_service.h
@@ -29,6 +29,15 @@ class ModelService {
    */
   cpp::result<void, std::string> DeleteModel(const std::string& model_handle);
 
+  cpp::result<bool, std::string> StartModel(const std::string& host, int port,
+                                            const std::string& model_handle);
+
+  cpp::result<bool, std::string> StopModel(const std::string& host, int port,
+                                           const std::string& model_handle);
+
+  cpp::result<bool, std::string> GetModelStatus(
+      const std::string& host, int port, const std::string& model_handle);
+
   cpp::result<std::string, std::string> HandleUrl(const std::string& url,
                                                   bool async = false);
 


### PR DESCRIPTION
## Describe Your Changes

- Add `/models/start` and `/models/stop` endpoint
- Fallback to cortex.llamacpp if engine is not in request body
- Use model_handle for model chat id

## Fixes Issues

- fixes https://github.com/janhq/cortex.cpp/issues/1372

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed