### PR TITLE
Fix: redownload model.yml

### DIFF
--- a/engine/database/models.cc
+++ b/engine/database/models.cc
@@ -86,7 +86,7 @@ std::string Models::GenerateShortenedAlias(
   std::vector<std::string> parts;
   std::istringstream iss(model_id);
   std::string part;
-  while (std::getline(iss, part, '/')) {
+  while (std::getline(iss, part, ':')) {
     parts.push_back(part);
   }
 
@@ -115,12 +115,12 @@ std::string Models::GenerateShortenedAlias(
 
   if (parts.size() >= 3) {
     candidates.push_back(parts[parts.size() - 3] + ":" +
-                         parts[parts.size() - 2] + "/" + filename);
+                         parts[parts.size() - 2] + ":" + filename);
   }
 
   if (parts.size() >= 4) {
-    candidates.push_back(parts[0] + ":" + parts[1] + "/" +
-                         parts[parts.size() - 2] + "/" + filename);
+    candidates.push_back(parts[0] + ":" + parts[1] + ":" +
+                         parts[parts.size() - 2] + ":" + filename);
   }
 
   // Find the first unique candidate

--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -72,7 +72,7 @@ cpp::result<bool, std::string> DownloadService::AddDownloadTask(
     if (result.has_error()) {
       dl_err_msg = result.error();
       break;
-    } else if(result) {
+    } else if (result) {
       has_task_done |= result.value();
     }
   }
@@ -174,7 +174,9 @@ cpp::result<bool, std::string> DownloadService::Download(
                                      << download_item.localPath.string()
                                      << " - " << existing_file_size);
       auto missing_bytes = download_item.bytes.value() - existing_file_size;
-      if (missing_bytes > 0) {
+      if (missing_bytes > 0 &&
+          download_item.localPath.extension().string() != ".yaml" &&
+          download_item.localPath.extension().string() != ".yml") {
         CLI_LOG("Found unfinished download! Additional "
                 << format_utils::BytesToHumanReadable(missing_bytes)
                 << " need to be downloaded.");
@@ -185,7 +187,7 @@ cpp::result<bool, std::string> DownloadService::Download(
           mode = "ab";
           CLI_LOG("Resuming download..");
         } else {
-          CLI_LOG("Start over..");          
+          CLI_LOG("Start over..");
         }
       } else {
         CLI_LOG(download_item.localPath.filename().string()

--- a/engine/test/components/test_models_db.cc
+++ b/engine/test/components/test_models_db.cc
@@ -85,7 +85,7 @@ TEST_F(ModelsTestSuite, TestGenerateShortenedAlias) {
   EXPECT_TRUE(model_list_.AddModelEntry(kTestModel).value());
   auto models1 = model_list_.LoadModelList();
   auto alias = model_list_.GenerateShortenedAlias(
-      "huggingface.co/bartowski/llama3.1-7b-gguf/Model_ID_Xxx.gguf",
+      "huggingface.co:bartowski:llama3.1-7b-gguf:Model_ID_Xxx.gguf",
       models1.value());
   EXPECT_EQ(alias, "model_id_xxx");
   EXPECT_TRUE(model_list_.UpdateModelAlias(kTestModel.model, alias).value());
@@ -93,7 +93,7 @@ TEST_F(ModelsTestSuite, TestGenerateShortenedAlias) {
   // Test with existing entries to force longer alias
   auto models2 = model_list_.LoadModelList();
   alias = model_list_.GenerateShortenedAlias(
-      "huggingface.co/bartowski/llama3.1-7b-gguf/Model_ID_Xxx.gguf",
+      "huggingface.co:bartowski:llama3.1-7b-gguf:Model_ID_Xxx.gguf",
       models2.value());
   EXPECT_EQ(alias, "llama3.1-7b-gguf:model_id_xxx");
 

--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -6,7 +6,6 @@
 #include "services/download_service.h"
 #include "utils/config_yaml_utils.h"
 
-
 #if defined(__APPLE__) && defined(__MACH__)
 #include <mach-o/dyld.h>
 #elif defined(__linux__)
@@ -145,6 +144,9 @@ inline void CreateConfigFileIfNotExist() {
 
   auto config = config_yaml_utils::CortexConfig{
       .logFolderPath = defaultDataFolderPath.string(),
+      .logLlamaCppPath = kLogsLlamacppBaseName,
+      .logTensorrtLLMPath = kLogsTensorrtllmBaseName,
+      .logOnnxPath = kLogsOnnxBaseName,
       .dataFolderPath = defaultDataFolderPath.string(),
       .maxLogLines = config_yaml_utils::kDefaultMaxLines,
       .apiServerHost = config_yaml_utils::kDefaultHost,


### PR DESCRIPTION
## Describe Your Changes

- Create default log path for engines at first time run cortexcpp
- Fix display issue when re download model.yml file. `model.yml` can be changed in local and file size can larger than original version in hugging face, this causes the problem that number of left bytes to download overflow.

## Fixes Issues
![image](https://github.com/user-attachments/assets/99846b6c-5084-485c-8fcf-9d6410d9f832)


