### PR TITLE
Fix/skip re download model yml

### DIFF
--- a/engine/commands/chat_completion_cmd.cc
+++ b/engine/commands/chat_completion_cmd.cc
@@ -1,6 +1,7 @@
 #include "chat_completion_cmd.h"
 #include "httplib.h"
 
+#include "config/yaml_config.h"
 #include "cortex_upd_cmd.h"
 #include "database/models.h"
 #include "model_status_cmd.h"
@@ -8,7 +9,6 @@
 #include "server_start_cmd.h"
 #include "trantor/utils/Logger.h"
 #include "utils/logging_utils.h"
-#include "config/yaml_config.h"
 
 namespace commands {
 namespace {
@@ -41,6 +41,8 @@ struct ChunkParser {
 
 void ChatCompletionCmd::Exec(const std::string& host, int port,
                              const std::string& model_handle, std::string msg) {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   cortex::db::Models modellist_handler;
   config::YamlHandler yaml_handler;
   try {
@@ -49,7 +51,10 @@ void ChatCompletionCmd::Exec(const std::string& host, int port,
       CLI_LOG("Error: " + model_entry.error());
       return;
     }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
+    yaml_handler.ModelConfigFromFile(
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.value().path_to_model_yaml))
+            .string());
     auto mc = yaml_handler.GetModelConfig();
     Exec(host, port, model_handle, mc, std::move(msg));
   } catch (const std::exception& e) {

--- a/engine/commands/chat_completion_cmd.cc
+++ b/engine/commands/chat_completion_cmd.cc
@@ -52,8 +52,8 @@ void ChatCompletionCmd::Exec(const std::string& host, int port,
       return;
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto mc = yaml_handler.GetModelConfig();
     Exec(host, port, model_handle, mc, std::move(msg));

--- a/engine/commands/model_get_cmd.cc
+++ b/engine/commands/model_get_cmd.cc
@@ -22,8 +22,8 @@ void ModelGetCmd::Exec(const std::string& model_handle) {
       return;
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto model_config = yaml_handler.GetModelConfig();
 

--- a/engine/commands/model_get_cmd.cc
+++ b/engine/commands/model_get_cmd.cc
@@ -11,6 +11,8 @@
 namespace commands {
 
 void ModelGetCmd::Exec(const std::string& model_handle) {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   cortex::db::Models modellist_handler;
   config::YamlHandler yaml_handler;
   try {
@@ -19,7 +21,10 @@ void ModelGetCmd::Exec(const std::string& model_handle) {
       CLI_LOG("Error: " + model_entry.error());
       return;
     }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
+    yaml_handler.ModelConfigFromFile(
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.value().path_to_model_yaml))
+            .string());
     auto model_config = yaml_handler.GetModelConfig();
 
     std::cout << model_config.ToString() << std::endl;

--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -29,7 +29,7 @@ void ModelImportCmd::Exec() {
     auto yaml_rel_path =
         fmu::Subtract(fs::path(model_yaml_path), fmu::GetCortexDataPath());
     cortex::db::ModelEntry model_entry{model_handle_, "local", "imported",
-                                       yaml_rel_path, model_handle_};
+                                       yaml_rel_path.string(), model_handle_};
 
     std::filesystem::create_directories(
         std::filesystem::path(model_yaml_path).parent_path());

--- a/engine/commands/model_import_cmd.cc
+++ b/engine/commands/model_import_cmd.cc
@@ -27,7 +27,7 @@ void ModelImportCmd::Exec() {
   try {
     // Use relative path for model_yaml_path. In case of import, we use absolute path for model
     auto yaml_rel_path =
-        fmu::Subtract(fs::path(model_yaml_path), fmu::GetCortexDataPath());
+        fmu::ToRelativeCortexDataPath(fs::path(model_yaml_path));
     cortex::db::ModelEntry model_entry{model_handle_, "local", "imported",
                                        yaml_rel_path.string(), model_handle_};
 

--- a/engine/commands/model_list_cmd.cc
+++ b/engine/commands/model_list_cmd.cc
@@ -10,6 +10,8 @@
 namespace commands {
 
 void ModelListCmd::Exec() {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   auto models_path = file_manager_utils::GetModelsContainerPath();
   cortex::db::Models modellist_handler;
   config::YamlHandler yaml_handler;
@@ -29,7 +31,10 @@ void ModelListCmd::Exec() {
     // auto model_entry = modellist_handler.GetModelInfo(model_handle);
     try {
       count += 1;
-      yaml_handler.ModelConfigFromFile(model_entry.path_to_model_yaml);
+      yaml_handler.ModelConfigFromFile(
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.path_to_model_yaml))
+            .string());
       auto model_config = yaml_handler.GetModelConfig();
       table.add_row({std::to_string(count), model_entry.model,
                      model_entry.model_alias, model_config.engine,

--- a/engine/commands/model_list_cmd.cc
+++ b/engine/commands/model_list_cmd.cc
@@ -32,9 +32,9 @@ void ModelListCmd::Exec() {
     try {
       count += 1;
       yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.path_to_model_yaml))
-            .string());
+          fmu::ToAbsoluteCortexDataPath(
+              fs::path(model_entry.path_to_model_yaml))
+              .string());
       auto model_config = yaml_handler.GetModelConfig();
       table.add_row({std::to_string(count), model_entry.model,
                      model_entry.model_alias, model_config.engine,

--- a/engine/commands/model_upd_cmd.cc
+++ b/engine/commands/model_upd_cmd.cc
@@ -1,5 +1,5 @@
 #include "model_upd_cmd.h"
-
+#include "utils/file_manager_utils.h"
 #include "utils/logging_utils.h"
 
 namespace commands {
@@ -9,13 +9,18 @@ ModelUpdCmd::ModelUpdCmd(std::string model_handle)
 
 void ModelUpdCmd::Exec(
     const std::unordered_map<std::string, std::string>& options) {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   try {
     auto model_entry = model_list_utils_.GetModelInfo(model_handle_);
     if (model_entry.has_error()) {
       CLI_LOG("Error: " + model_entry.error());
       return;
     }
-    yaml_handler_.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
+    auto yaml_fp =
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.value().path_to_model_yaml));
+    yaml_handler_.ModelConfigFromFile(yaml_fp.string());
     model_config_ = yaml_handler_.GetModelConfig();
 
     for (const auto& [key, value] : options) {
@@ -25,7 +30,7 @@ void ModelUpdCmd::Exec(
     }
 
     yaml_handler_.UpdateModelConfig(model_config_);
-    yaml_handler_.WriteYamlFile(model_entry.value().path_to_model_yaml);
+    yaml_handler_.WriteYamlFile(yaml_fp.string());
     CLI_LOG("Successfully updated model ID '" + model_handle_ + "'!");
   } catch (const std::exception& e) {
     CLI_LOG("Failed to update model with model ID '" + model_handle_ +

--- a/engine/commands/model_upd_cmd.cc
+++ b/engine/commands/model_upd_cmd.cc
@@ -17,9 +17,8 @@ void ModelUpdCmd::Exec(
       CLI_LOG("Error: " + model_entry.error());
       return;
     }
-    auto yaml_fp =
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml));
+    auto yaml_fp = fmu::ToAbsoluteCortexDataPath(
+        fs::path(model_entry.value().path_to_model_yaml));
     yaml_handler_.ModelConfigFromFile(yaml_fp.string());
     model_config_ = yaml_handler_.GetModelConfig();
 

--- a/engine/commands/run_cmd.cc
+++ b/engine/commands/run_cmd.cc
@@ -32,12 +32,17 @@ void RunCmd::Exec(bool chat_flag) {
   }
 
   try {
+    namespace fs = std::filesystem;
+    namespace fmu = file_manager_utils;
     auto model_entry = modellist_handler.GetModelInfo(*model_id);
     if (model_entry.has_error()) {
       CLI_LOG("Error: " + model_entry.error());
       return;
     }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
+    yaml_handler.ModelConfigFromFile(
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.value().path_to_model_yaml))
+            .string());
     auto mc = yaml_handler.GetModelConfig();
 
     // Check if engine existed. If not, download it

--- a/engine/commands/run_cmd.cc
+++ b/engine/commands/run_cmd.cc
@@ -40,8 +40,8 @@ void RunCmd::Exec(bool chat_flag) {
       return;
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto mc = yaml_handler.GetModelConfig();
 

--- a/engine/config/yaml_config.cc
+++ b/engine/config/yaml_config.cc
@@ -27,7 +27,7 @@ void YamlHandler::ReadYamlFile(const std::string& file_path) {
       if (yaml_node_["engine"] &&
           yaml_node_["engine"].as<std::string>() == "cortex.llamacpp") {
         auto abs_path = s.substr(0, s.find_last_of('/')) + "/model.gguf";
-        auto rel_path = fmu::Subtract(fs::path(abs_path), fmu::GetCortexDataPath());
+        auto rel_path = fmu::ToRelativeCortexDataPath(fs::path(abs_path));
         v.emplace_back(rel_path.string());
       } else {
         v.emplace_back(s.substr(0, s.find_last_of('/')));

--- a/engine/config/yaml_config.cc
+++ b/engine/config/yaml_config.cc
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-using namespace std;
 
 #include "utils/format_utils.h"
 #include "utils/file_manager_utils.h"

--- a/engine/config/yaml_config.cc
+++ b/engine/config/yaml_config.cc
@@ -289,9 +289,7 @@ void YamlHandler::WriteYamlFile(const std::string& file_path) const {
       outFile << "version: " << yaml_node_["version"].as<std::string>() << "\n";
     }
     if (yaml_node_["files"] && yaml_node_["files"].size()) {
-      outFile << "files:             # can be universal protocol (models://) "
-                 "OR absolute local file path (file://) OR https remote URL "
-                 "(https://)\n";
+      outFile << "files:             # Can be relative OR absolute local file path\n";
       for (const auto& source : yaml_node_["files"]) {
         outFile << "  - " << source << "\n";
       }

--- a/engine/config/yaml_config.cc
+++ b/engine/config/yaml_config.cc
@@ -6,6 +6,7 @@
 using namespace std;
 
 #include "utils/format_utils.h"
+#include "utils/file_manager_utils.h"
 #include "yaml_config.h"
 namespace config {
 // Method to read YAML file
@@ -14,6 +15,8 @@ void YamlHandler::Reset() {
   yaml_node_.reset();
 };
 void YamlHandler::ReadYamlFile(const std::string& file_path) {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   try {
     yaml_node_ = YAML::LoadFile(file_path);
     // incase of model.yml file, we don't have files yet, create them
@@ -24,8 +27,9 @@ void YamlHandler::ReadYamlFile(const std::string& file_path) {
       std::vector<std::string> v;
       if (yaml_node_["engine"] &&
           yaml_node_["engine"].as<std::string>() == "cortex.llamacpp") {
-        // TODO: change prefix to models:// with source from cortexso
-        v.emplace_back(s.substr(0, s.find_last_of('/')) + "/model.gguf");
+        auto abs_path = s.substr(0, s.find_last_of('/')) + "/model.gguf";
+        auto rel_path = fmu::Subtract(fs::path(abs_path), fmu::GetCortexDataPath());
+        v.emplace_back(rel_path.string());
       } else {
         v.emplace_back(s.substr(0, s.find_last_of('/')));
       }

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -245,7 +245,7 @@ void Models::ImportModel(
     auto yaml_rel_path =
         fmu::Subtract(fs::path(model_yaml_path), fmu::GetCortexDataPath());
     cortex::db::ModelEntry model_entry{modelHandle, "local", "imported",
-                                       yaml_rel_path, modelHandle};
+                                       yaml_rel_path.string(), modelHandle};
 
     std::filesystem::create_directories(
         std::filesystem::path(model_yaml_path).parent_path());

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -76,8 +76,8 @@ void Models::ListModel(
       // auto model_entry = modellist_handler.GetModelInfo(model_handle);
       try {
         yaml_handler.ModelConfigFromFile(
-            fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                                 fs::path(model_entry.path_to_model_yaml))
+            fmu::ToAbsoluteCortexDataPath(
+                fs::path(model_entry.path_to_model_yaml))
                 .string());
         auto model_config = yaml_handler.GetModelConfig();
         Json::Value obj = model_config.ToJson();
@@ -132,8 +132,8 @@ void Models::GetModel(const HttpRequestPtr& req,
       return;
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto model_config = yaml_handler.GetModelConfig();
 
@@ -187,9 +187,8 @@ void Models::UpdateModel(const HttpRequestPtr& req,
     cortex::db::Models model_list_utils;
     auto model_entry = model_list_utils.GetModelInfo(model_id);
     config::YamlHandler yaml_handler;
-    auto yaml_fp =
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml));
+    auto yaml_fp = fmu::ToAbsoluteCortexDataPath(
+        fs::path(model_entry.value().path_to_model_yaml));
     yaml_handler.ModelConfigFromFile(yaml_fp.string());
     config::ModelConfig model_config = yaml_handler.GetModelConfig();
     model_config.FromJson(json_body);
@@ -243,7 +242,7 @@ void Models::ImportModel(
   try {
     // Use relative path for model_yaml_path. In case of import, we use absolute path for model
     auto yaml_rel_path =
-        fmu::Subtract(fs::path(model_yaml_path), fmu::GetCortexDataPath());
+        fmu::ToRelativeCortexDataPath(fs::path(model_yaml_path));
     cortex::db::ModelEntry model_entry{modelHandle, "local", "imported",
                                        yaml_rel_path.string(), modelHandle};
 

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -59,6 +59,8 @@ void Models::PullModel(const HttpRequestPtr& req,
 void Models::ListModel(
     const HttpRequestPtr& req,
     std::function<void(const HttpResponsePtr&)>&& callback) const {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   Json::Value ret;
   ret["object"] = "list";
   Json::Value data(Json::arrayValue);
@@ -73,8 +75,10 @@ void Models::ListModel(
     for (const auto& model_entry : list_entry.value()) {
       // auto model_entry = modellist_handler.GetModelInfo(model_handle);
       try {
-
-        yaml_handler.ModelConfigFromFile(model_entry.path_to_model_yaml);
+        yaml_handler.ModelConfigFromFile(
+            fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                                 fs::path(model_entry.path_to_model_yaml))
+                .string());
         auto model_config = yaml_handler.GetModelConfig();
         Json::Value obj = model_config.ToJson();
 
@@ -106,6 +110,8 @@ void Models::ListModel(
 void Models::GetModel(const HttpRequestPtr& req,
                       std::function<void(const HttpResponsePtr&)>&& callback,
                       const std::string& model_id) const {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   LOG_DEBUG << "GetModel, Model handle: " << model_id;
   Json::Value ret;
   ret["object"] = "list";
@@ -125,7 +131,10 @@ void Models::GetModel(const HttpRequestPtr& req,
       callback(resp);
       return;
     }
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
+    yaml_handler.ModelConfigFromFile(
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.value().path_to_model_yaml))
+            .string());
     auto model_config = yaml_handler.GetModelConfig();
 
     Json::Value obj = model_config.ToJson();
@@ -137,8 +146,8 @@ void Models::GetModel(const HttpRequestPtr& req,
     resp->setStatusCode(k200OK);
     callback(resp);
   } catch (const std::exception& e) {
-    std::string message = "Fail to get model information with ID '" +
-                          model_id + "': " + e.what();
+    std::string message =
+        "Fail to get model information with ID '" + model_id + "': " + e.what();
     LOG_ERROR << message;
     ret["data"] = data;
     ret["result"] = "Fail to get model information";
@@ -171,16 +180,21 @@ void Models::DeleteModel(const HttpRequestPtr& req,
 void Models::UpdateModel(const HttpRequestPtr& req,
                          std::function<void(const HttpResponsePtr&)>&& callback,
                          const std::string& model_id) const {
+  namespace fs = std::filesystem;
+  namespace fmu = file_manager_utils;
   auto json_body = *(req->getJsonObject());
   try {
     cortex::db::Models model_list_utils;
     auto model_entry = model_list_utils.GetModelInfo(model_id);
     config::YamlHandler yaml_handler;
-    yaml_handler.ModelConfigFromFile(model_entry.value().path_to_model_yaml);
+    auto yaml_fp =
+        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
+                             fs::path(model_entry.value().path_to_model_yaml));
+    yaml_handler.ModelConfigFromFile(yaml_fp.string());
     config::ModelConfig model_config = yaml_handler.GetModelConfig();
     model_config.FromJson(json_body);
     yaml_handler.UpdateModelConfig(model_config);
-    yaml_handler.WriteYamlFile(model_entry.value().path_to_model_yaml);
+    yaml_handler.WriteYamlFile(yaml_fp.string());
     std::string message = "Successfully update model ID '" + model_id +
                           "': " + json_body.toStyledString();
     LOG_INFO << message;
@@ -295,13 +309,13 @@ void Models::SetModelAlias(
     if (result.has_error()) {
       std::string message = result.error();
       LOG_ERROR << message;
-        Json::Value ret;
-        ret["result"] = "Set alias failed!";
-        ret["modelHandle"] = model_handle;
-        ret["message"] = message;
-        auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
-        resp->setStatusCode(k400BadRequest);
-        callback(resp);
+      Json::Value ret;
+      ret["result"] = "Set alias failed!";
+      ret["modelHandle"] = model_handle;
+      ret["message"] = message;
+      auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
+      resp->setStatusCode(k400BadRequest);
+      callback(resp);
     } else {
       if (result.value()) {
         std::string message = "Successfully set model alias '" + model_alias +

--- a/engine/database/models.cc
+++ b/engine/database/models.cc
@@ -86,7 +86,7 @@ std::string Models::GenerateShortenedAlias(
   std::vector<std::string> parts;
   std::istringstream iss(model_id);
   std::string part;
-  while (std::getline(iss, part, '/')) {
+  while (std::getline(iss, part, ':')) {
     parts.push_back(part);
   }
 
@@ -115,12 +115,12 @@ std::string Models::GenerateShortenedAlias(
 
   if (parts.size() >= 3) {
     candidates.push_back(parts[parts.size() - 3] + ":" +
-                         parts[parts.size() - 2] + "/" + filename);
+                         parts[parts.size() - 2] + ":" + filename);
   }
 
   if (parts.size() >= 4) {
-    candidates.push_back(parts[0] + ":" + parts[1] + "/" +
-                         parts[parts.size() - 2] + "/" + filename);
+    candidates.push_back(parts[0] + ":" + parts[1] + ":" +
+                         parts[parts.size() - 2] + ":" + filename);
   }
 
   // Find the first unique candidate

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -46,8 +46,8 @@ void RunServer() {
       std::filesystem::path(config.logFolderPath) /
       std::filesystem::path(cortex_utils::logs_folder));
   trantor::FileLogger asyncFileLogger;
-  asyncFileLogger.setFileName(config.logFolderPath + "/" +
-                              cortex_utils::logs_base_name);
+  asyncFileLogger.setFileName((std::filesystem::path(config.logFolderPath) /
+      std::filesystem::path(cortex_utils::logs_base_name)).string());
   asyncFileLogger.setMaxLines(config.maxLogLines);  // Keep last 100000 lines
   asyncFileLogger.startLogging();
   trantor::Logger::setOutputFunction(

--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -72,7 +72,7 @@ cpp::result<bool, std::string> DownloadService::AddDownloadTask(
     if (result.has_error()) {
       dl_err_msg = result.error();
       break;
-    } else if(result) {
+    } else if (result) {
       has_task_done |= result.value();
     }
   }
@@ -174,7 +174,9 @@ cpp::result<bool, std::string> DownloadService::Download(
                                      << download_item.localPath.string()
                                      << " - " << existing_file_size);
       auto missing_bytes = download_item.bytes.value() - existing_file_size;
-      if (missing_bytes > 0) {
+      if (missing_bytes > 0 &&
+          download_item.localPath.extension().string() != ".yaml" &&
+          download_item.localPath.extension().string() != ".yml") {
         CLI_LOG("Found unfinished download! Additional "
                 << format_utils::BytesToHumanReadable(missing_bytes)
                 << " need to be downloaded.");
@@ -185,7 +187,7 @@ cpp::result<bool, std::string> DownloadService::Download(
           mode = "ab";
           CLI_LOG("Resuming download..");
         } else {
-          CLI_LOG("Start over..");          
+          CLI_LOG("Start over..");
         }
       } else {
         CLI_LOG(download_item.localPath.filename().string()

--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -173,6 +173,7 @@ cpp::result<bool, std::string> DownloadService::Download(
       CTL_INF("Existing file size: " << download_item.downloadUrl << " - "
                                      << download_item.localPath.string()
                                      << " - " << existing_file_size);
+      CTL_INF("Download item size: " << download_item.bytes.value());                               
       auto missing_bytes = download_item.bytes.value() - existing_file_size;
       if (missing_bytes > 0) {
         CLI_LOG("Found unfinished download! Additional "

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -27,8 +27,8 @@ void ParseGguf(const DownloadItem& ggufDownloadItem,
   model_config.id =
       ggufDownloadItem.localPath.parent_path().filename().string();
   // use relative path for files
-  auto file_rel_path = fmu::Subtract(fs::path(ggufDownloadItem.localPath),
-                                     fmu::GetCortexDataPath());
+  auto file_rel_path =
+      fmu::ToRelativeCortexDataPath(fs::path(ggufDownloadItem.localPath));
   model_config.files = {file_rel_path.string()};
   model_config.model = ggufDownloadItem.id;
   yaml_handler.UpdateModelConfig(model_config);
@@ -44,8 +44,7 @@ void ParseGguf(const DownloadItem& ggufDownloadItem,
   auto branch = url_obj.pathParams[3];
   CTL_INF("Adding model to modellist with branch: " << branch);
 
-  auto rel = file_manager_utils::Subtract(
-      yaml_name, file_manager_utils::GetCortexDataPath());
+  auto rel = file_manager_utils::ToRelativeCortexDataPath(yaml_name);
   CTL_INF("path_to_model_yaml: " << rel.string());
 
   auto author_id = author.has_value() ? author.value() : "cortexso";
@@ -304,8 +303,8 @@ cpp::result<std::string, std::string> ModelService::DownloadModelFromCortexso(
     yaml_handler.UpdateModelConfig(mc);
     yaml_handler.WriteYamlFile(model_yml_item->localPath.string());
 
-    auto rel = file_manager_utils::Subtract(
-        model_yml_item->localPath, file_manager_utils::GetCortexDataPath());
+    auto rel =
+        file_manager_utils::ToRelativeCortexDataPath(model_yml_item->localPath);
     CTL_INF("path_to_model_yaml: " << rel.string());
 
     cortex::db::Models modellist_utils_obj;
@@ -376,9 +375,8 @@ cpp::result<void, std::string> ModelService::DeleteModel(
       CTL_WRN("Error: " + model_entry.error());
       return cpp::fail(model_entry.error());
     }
-    auto yaml_fp =
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml));
+    auto yaml_fp = fmu::ToAbsoluteCortexDataPath(
+        fs::path(model_entry.value().path_to_model_yaml));
     yaml_handler.ModelConfigFromFile(yaml_fp.string());
     auto mc = yaml_handler.GetModelConfig();
     // Remove yaml file
@@ -389,12 +387,12 @@ cpp::result<void, std::string> ModelService::DeleteModel(
         if (mc.engine == "cortex.llamacpp") {
           for (auto& file : mc.files) {
             std::filesystem::path gguf_p(
-                fmu::GetAbsolutePath(fmu::GetCortexDataPath(), fs::path(file)));
+                fmu::ToAbsoluteCortexDataPath(fs::path(file)));
             std::filesystem::remove(gguf_p);
           }
         } else {
-          std::filesystem::path f(fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                                                       fs::path(mc.files[0])));
+          std::filesystem::path f(
+              fmu::ToAbsoluteCortexDataPath(fs::path(mc.files[0])));
           std::filesystem::remove_all(f);
         }
       } else {
@@ -428,8 +426,8 @@ cpp::result<bool, std::string> ModelService::StartModel(
       return cpp::fail(model_entry.error());
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto mc = yaml_handler.GetModelConfig();
 
@@ -439,8 +437,7 @@ cpp::result<bool, std::string> ModelService::StartModel(
     if (mc.files.size() > 0) {
       // TODO(sang) support multiple files
       json_data["model_path"] =
-          fmu::GetAbsolutePath(fmu::GetCortexDataPath(), fs::path(mc.files[0]))
-              .string();
+          fmu::ToAbsoluteCortexDataPath(fs::path(mc.files[0])).string();
     } else {
       LOG_WARN << "model_path is empty";
       return false;
@@ -489,8 +486,8 @@ cpp::result<bool, std::string> ModelService::StopModel(
       return cpp::fail(model_entry.error());
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto mc = yaml_handler.GetModelConfig();
 
@@ -538,8 +535,8 @@ cpp::result<bool, std::string> ModelService::GetModelStatus(
       return cpp::fail(model_entry.error());
     }
     yaml_handler.ModelConfigFromFile(
-        fmu::GetAbsolutePath(fmu::GetCortexDataPath(),
-                             fs::path(model_entry.value().path_to_model_yaml))
+        fmu::ToAbsoluteCortexDataPath(
+            fs::path(model_entry.value().path_to_model_yaml))
             .string());
     auto mc = yaml_handler.GetModelConfig();
 

--- a/engine/test/components/test_models_db.cc
+++ b/engine/test/components/test_models_db.cc
@@ -85,7 +85,7 @@ TEST_F(ModelsTestSuite, TestGenerateShortenedAlias) {
   EXPECT_TRUE(model_list_.AddModelEntry(kTestModel).value());
   auto models1 = model_list_.LoadModelList();
   auto alias = model_list_.GenerateShortenedAlias(
-      "huggingface.co/bartowski/llama3.1-7b-gguf/Model_ID_Xxx.gguf",
+      "huggingface.co:bartowski:llama3.1-7b-gguf:Model_ID_Xxx.gguf",
       models1.value());
   EXPECT_EQ(alias, "model_id_xxx");
   EXPECT_TRUE(model_list_.UpdateModelAlias(kTestModel.model, alias).value());
@@ -93,7 +93,7 @@ TEST_F(ModelsTestSuite, TestGenerateShortenedAlias) {
   // Test with existing entries to force longer alias
   auto models2 = model_list_.LoadModelList();
   alias = model_list_.GenerateShortenedAlias(
-      "huggingface.co/bartowski/llama3.1-7b-gguf/Model_ID_Xxx.gguf",
+      "huggingface.co:bartowski:llama3.1-7b-gguf:Model_ID_Xxx.gguf",
       models2.value());
   EXPECT_EQ(alias, "llama3.1-7b-gguf:model_id_xxx");
 

--- a/engine/test/components/test_paths.cc
+++ b/engine/test/components/test_paths.cc
@@ -1,0 +1,57 @@
+#include "gtest/gtest.h"
+#include "utils/file_manager_utils.h"
+
+namespace file_manager_utils {
+// Test suite
+class PathTests : public ::testing::Test {};
+
+// Test cases for GetAbsolutePath
+TEST_F(PathTests, GetAbsolutePath_AbsolutePath_ReturnsSamePath) {
+  auto base = std::filesystem::path("/base");
+  auto relative = std::filesystem::path("/absolute/path");
+  EXPECT_EQ(GetAbsolutePath(base, relative), relative);
+}
+
+TEST_F(PathTests, GetAbsolutePath_RelativePath_ReturnsCombinedPath) {
+  auto base = std::filesystem::path("/base");
+  auto relative = std::filesystem::path("relative/path");
+  EXPECT_EQ(GetAbsolutePath(base, relative), base / relative);
+}
+
+// Test cases for IsSubpath
+TEST_F(PathTests, IsSubpath_Subpath_ReturnsTrue) {
+  auto base = std::filesystem::path("/base");
+  auto subpath = std::filesystem::path("/base/relative/path");
+  EXPECT_TRUE(IsSubpath(base, subpath));
+}
+
+TEST_F(PathTests, IsSubpath_NotSubpath_ReturnsFalse) {
+  auto base = std::filesystem::path("/base");
+  auto notSubpath = std::filesystem::path("/other/path");
+  EXPECT_FALSE(IsSubpath(base, notSubpath));
+}
+
+TEST_F(PathTests, IsSubpath_EmptyRelative_ReturnsFalse) {
+  auto base = std::filesystem::path("/base");
+  auto emptyPath = std::filesystem::path("/base/");
+  EXPECT_FALSE(IsSubpath(base, emptyPath));
+}
+
+// Test cases for Subtract
+TEST_F(PathTests, Subtract_SubtractingBaseFromSubPath_ReturnsRelativePath) {
+  auto base = std::filesystem::path("/base");
+  auto subPath = std::filesystem::path("/base/relative/path");
+  EXPECT_EQ(Subtract(subPath, base), std::filesystem::path("relative/path"));
+}
+
+TEST_F(PathTests, Subtract_NotASubPath_ReturnsOriginalPath) {
+  auto base = std::filesystem::path("/base");
+  auto notSubPath = std::filesystem::path("/other/path");
+  EXPECT_EQ(Subtract(notSubPath, base), notSubPath);
+}
+
+TEST_F(PathTests, Subtract_IdenticalPaths_ReturnsEmptyRelative) {
+  auto base = std::filesystem::path("/base");
+  EXPECT_EQ(Subtract(base, base), std::filesystem::path("."));
+}
+}  // namespace file_manager_utils

--- a/engine/test/components/test_paths.cc
+++ b/engine/test/components/test_paths.cc
@@ -27,27 +27,32 @@ TEST_F(PathTests, IsSubpath_Subpath_ReturnsTrue) {
 
 TEST_F(PathTests, IsSubpath_NotSubpath_ReturnsFalse) {
   auto base = std::filesystem::path("/base");
-  auto notSubpath = std::filesystem::path("/other/path");
-  EXPECT_FALSE(IsSubpath(base, notSubpath));
+  auto not_subpath = std::filesystem::path("/other/path");
+  EXPECT_FALSE(IsSubpath(base, not_subpath));
 }
 
 TEST_F(PathTests, IsSubpath_EmptyRelative_ReturnsFalse) {
   auto base = std::filesystem::path("/base");
-  auto emptyPath = std::filesystem::path("/base/");
-  EXPECT_FALSE(IsSubpath(base, emptyPath));
+  auto empty_path = std::filesystem::path("");
+  EXPECT_FALSE(IsSubpath(base, empty_path));
+}
+
+TEST_F(PathTests, IsSubpath_SamePath_ReturnsTrue) {
+  auto base = std::filesystem::path("/base");  
+  EXPECT_TRUE(IsSubpath(base, base));
 }
 
 // Test cases for Subtract
 TEST_F(PathTests, Subtract_SubtractingBaseFromSubPath_ReturnsRelativePath) {
   auto base = std::filesystem::path("/base");
-  auto subPath = std::filesystem::path("/base/relative/path");
-  EXPECT_EQ(Subtract(subPath, base), std::filesystem::path("relative/path"));
+  auto subpath = std::filesystem::path("/base/relative/path");
+  EXPECT_EQ(Subtract(subpath, base), std::filesystem::path("relative/path"));
 }
 
 TEST_F(PathTests, Subtract_NotASubPath_ReturnsOriginalPath) {
   auto base = std::filesystem::path("/base");
-  auto notSubPath = std::filesystem::path("/other/path");
-  EXPECT_EQ(Subtract(notSubPath, base), notSubPath);
+  auto not_subpath = std::filesystem::path("/other/path");
+  EXPECT_EQ(Subtract(not_subpath, base), not_subpath);
 }
 
 TEST_F(PathTests, Subtract_IdenticalPaths_ReturnsEmptyRelative) {

--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -6,7 +6,6 @@
 #include "services/download_service.h"
 #include "utils/config_yaml_utils.h"
 
-
 #if defined(__APPLE__) && defined(__MACH__)
 #include <mach-o/dyld.h>
 #elif defined(__linux__)
@@ -145,6 +144,9 @@ inline void CreateConfigFileIfNotExist() {
 
   auto config = config_yaml_utils::CortexConfig{
       .logFolderPath = defaultDataFolderPath.string(),
+      .logLlamaCppPath = kLogsLlamacppBaseName,
+      .logTensorrtLLMPath = kLogsTensorrtllmBaseName,
+      .logOnnxPath = kLogsOnnxBaseName,
       .dataFolderPath = defaultDataFolderPath.string(),
       .maxLogLines = config_yaml_utils::kDefaultMaxLines,
       .apiServerHost = config_yaml_utils::kDefaultHost,

--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -302,6 +302,8 @@ inline std::filesystem::path GetAbsolutePath(const std::filesystem::path& base,
 
 inline bool IsSubpath(const std::filesystem::path& base,
                       const std::filesystem::path& path) {
+  if (base == path)
+    return true;
   auto rel = std::filesystem::relative(path, base);
   return !rel.empty() && rel.native()[0] != '.';
 }

--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -6,7 +6,6 @@
 #include "services/download_service.h"
 #include "utils/config_yaml_utils.h"
 
-
 #if defined(__APPLE__) && defined(__MACH__)
 #include <mach-o/dyld.h>
 #elif defined(__linux__)
@@ -289,6 +288,30 @@ inline std::string DownloadTypeToString(DownloadType type) {
       return "Cortex";
     default:
       return "UNKNOWN";
+  }
+}
+
+inline std::filesystem::path GetAbsolutePath(const std::filesystem::path& base,
+                                             const std::filesystem::path& r) {
+  if (r.is_absolute()) {
+    return r;
+  } else {
+    return base / r;
+  }
+}
+
+inline bool IsSubpath(const std::filesystem::path& base,
+                      const std::filesystem::path& path) {
+  auto rel = std::filesystem::relative(path, base);
+  return !rel.empty() && rel.native()[0] != '.';
+}
+
+inline std::filesystem::path Subtract(const std::filesystem::path& path,
+                                      const std::filesystem::path& base) {
+  if (IsSubpath(base, path)) {
+    return path.lexically_relative(base);
+  } else {
+    return path;
   }
 }
 

--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -317,4 +317,14 @@ inline std::filesystem::path Subtract(const std::filesystem::path& path,
   }
 }
 
+inline std::filesystem::path ToRelativeCortexDataPath(
+    const std::filesystem::path& path) {
+  return Subtract(path, GetCortexDataPath());
+}
+
+inline std::filesystem::path ToAbsoluteCortexDataPath(
+    const std::filesystem::path& path) {
+  return GetAbsolutePath(GetCortexDataPath(), path);
+}
+
 }  // namespace file_manager_utils


### PR DESCRIPTION
Fix #1412 
Fixes #1384

## Describe Your Changes

- Create default log path for engines at first time run cortexcpp
- Fix display issue when re download model.yml file. `model.yml` can be changed in local and file size can larger than original version in hugging face, this causes the problem that number of left bytes to download overflow.

## Fixes Issues
![image](https://github.com/user-attachments/assets/99846b6c-5084-485c-8fcf-9d6410d9f832)


