### PR TITLE
Chore: Improve User Experience in Cortex Uninstall Scripts for Linux and macOS

### DIFF
--- a/engine/templates/linux/postrm
+++ b/engine/templates/linux/postrm
@@ -3,28 +3,40 @@ set +e
 DATA_FOLDER_NAME=.cortex
 CONFIGURATION_FILE_NAME=.cortexrc
 
-echo "Do you want to delete the ~/$DATA_FOLDER_NAME data folder and file ~/$CONFIGURATION_FILE_NAME? (yes/no)"
+echo "Do you want to delete the ~/$DATA_FOLDER_NAME data folder and file ~/$CONFIGURATION_FILE_NAME? (yes/no) [default: no]"
 read -r answer
 
+# Determine the home directory based on the user
 USER_TO_RUN_AS=${SUDO_USER:-$(whoami)}
+if [ "$USER_TO_RUN_AS" = "root" ]; then
+    USER_HOME="/root"
+else
+    USER_HOME="/home/$USER_TO_RUN_AS"
+fi
 
-case "$answer" in
-    [yY][eE][sS]|[yY])
-        echo "Deleting cortex data folders..."
-        if [ -d "/home/$USER_TO_RUN_AS/$DATA_FOLDER_NAME" ]; then
-            echo "Removing /home/$USER_TO_RUN_AS/$DATA_FOLDER_NAME"
-            rm -rf "/home/$USER_TO_RUN_AS/$DATA_FOLDER_NAME" > /dev/null 2>&1
-        fi
-        if [ -f "/home/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME" ]; then
-            echo "Removing /home/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME"
-            rm -f "/home/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME" > /dev/null 2>&1
-        fi
-        ;;
-    [nN][oO]|[nN])
-        echo "Keeping the 'cortex' data folders."
-        ;;
-    *)
-        echo "Invalid response. Please type 'yes' or 'no'."
-        ;;
-esac
+while true; do
+    case "$answer" in
+        [yY][eE][sS]|[yY])
+            echo "Deleting cortex data folders..."
+            if [ -d "$USER_HOME/$DATA_FOLDER_NAME" ]; then
+                echo "Removing $USER_HOME/$DATA_FOLDER_NAME"
+                rm -rf "$USER_HOME/$DATA_FOLDER_NAME" > /dev/null 2>&1
+            fi
+            if [ -f "$USER_HOME/$CONFIGURATION_FILE_NAME" ]; then
+                echo "Removing $USER_HOME/$CONFIGURATION_FILE_NAME"
+                rm -f "$USER_HOME/$CONFIGURATION_FILE_NAME" > /dev/null 2>&1
+            fi
+            break
+            ;;
+        [nN][oO]|[nN]|"")
+            echo "Keeping the 'cortex' data folders."
+            break
+            ;;
+        *)
+            echo "Invalid response. Please type 'yes', 'no', 'y', or 'n' (case-insensitive)."
+            read -r answer
+            ;;
+    esac
+done
+
 exit 0

--- a/engine/templates/macos/cortex-uninstall.sh
+++ b/engine/templates/macos/cortex-uninstall.sh
@@ -12,30 +12,43 @@ fi
 
 USER_TO_RUN_AS=${SUDO_USER:-$(whoami)}
 
-sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME stop > /dev/null 2>&1
+# Use /root if user is root, otherwise /Users/<username>
+if [ "$USER_TO_RUN_AS" = "root" ]; then
+    USER_HOME="/root"
+else
+    USER_HOME="/Users/$USER_TO_RUN_AS"
+fi
+
+sudo -u "$USER_TO_RUN_AS" /usr/local/bin/$DESTINATION_BINARY_NAME stop > /dev/null 2>&1
 rm /usr/local/bin/$DESTINATION_BINARY_NAME
 
-echo "Do you want to delete the '~/$DATA_FOLDER_NAME' data folder and file '~/$CONFIGURATION_FILE_NAME'? (yes/no)"
+echo "Do you want to delete the '$USER_HOME/$DATA_FOLDER_NAME' data folder and file '$USER_HOME/$CONFIGURATION_FILE_NAME'? (y/n) [default: n]"
 read -r answer
 
-case "$answer" in
-    [yY][eE][sS]|[yY])
-        echo "Deleting cortex data folders..."
-        if [ -d "/Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME" ]; then
-            echo "Removing /Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME"
-            rm -rf "/Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME" > /dev/null 2>&1
-        fi
-        if [ -f "/Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME" ]; then
-            echo "Removing /Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME"
-            rm -f "/Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME" > /dev/null 2>&1
-        fi
-        ;;
-    [nN][oO]|[nN])
-        echo "Keeping the 'cortex' data folders."
-        ;;
-    *)
-        echo "Invalid response. Please type 'yes' or 'no'."
-        ;;
-esac
+# Default to 'no' if no input is provided
+while true; do
+    case "$answer" in
+        [yY][eE][sS]|[yY])
+            echo "Deleting cortex data folders..."
+            if [ -d "$USER_HOME/$DATA_FOLDER_NAME" ]; then
+                echo "Removing $USER_HOME/$DATA_FOLDER_NAME"
+                rm -rf "$USER_HOME/$DATA_FOLDER_NAME" > /dev/null 2>&1
+            fi
+            if [ -f "$USER_HOME/$CONFIGURATION_FILE_NAME" ]; then
+                echo "Removing $USER_HOME/$CONFIGURATION_FILE_NAME"
+                rm -f "$USER_HOME/$CONFIGURATION_FILE_NAME" > /dev/null 2>&1
+            fi
+            break
+            ;;
+        [nN][oO]|[nN]|"")
+            echo "Keeping the 'cortex' data folders."
+            break
+            ;;
+        *)
+            echo "Invalid response. Please type 'yes', 'no', 'y', or 'n' (case-insensitive)."
+            read -r answer
+            ;;
+    esac
+done
 
 rm /usr/local/bin/$UNINSTALLER_FILE_NAME


### PR DESCRIPTION
## Describe Your Changes

This PR enhances the user experience (UX) in both Linux and macOS uninstall scripts by introducing the following improvements:

**1. Default 'no' for Deletion Confirmation:**

When prompted to delete the ~/.cortex data folder and .cortexrc configuration file, the script now defaults to 'no' if the user presses Enter without input. This prevents accidental data deletion.

**2. Input Validation with Continuous Prompt:**

If the user provides invalid input (anything other than 'yes', 'no', 'y', 'n'), the script now repeatedly prompts for valid input instead of exiting. This ensures the user can make a clear, informed choice.

**3. Home Directory Adjustments:**

For both Linux and macOS, if the script is run by the root user, the home directory is set to /root, instead of /home or /Users, ensuring correct file path handling for system administrators.
These improvements provide a more intuitive and safer interaction for users during the uninstall process.