### PR TITLE
fix: update link editurl field docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -342,7 +342,7 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/janhq/cortex.so/tree/main/",
+          editUrl: "https://github.com/janhq/cortex.cpp/blob/dev/docs/",
         },
         sitemap: {
           changefreq: "daily",


### PR DESCRIPTION
## Describe Your Changes
Since we moved the docs to this repo, we should also update the base edit URL link in Docusaurus

## Fixes Issues

- Conv https://discord.com/channels/1107178041848909847/1204617960615055401/1295242408916815913
- Closes #1428 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed