### PR TITLE
fix: return model_id instead of error if model is already downloaded

### DIFF
--- a/engine/cli/commands/run_cmd.cc
+++ b/engine/cli/commands/run_cmd.cc
@@ -35,6 +35,10 @@ void RunCmd::Exec(bool run_detach) {
     auto related_models_ids = modellist_handler.FindRelatedModel(model_handle_);
     if (related_models_ids.has_error() || related_models_ids.value().empty()) {
       auto result = model_service_.DownloadModel(model_handle_);
+      if(result.has_error()) {
+        CLI_LOG(result.error());
+        return;
+      }
       model_id = result.value();
       CTL_INF("model_id: " << model_id.value());
     } else if (related_models_ids.value().size() == 1) {

--- a/engine/cli/commands/run_cmd.cc
+++ b/engine/cli/commands/run_cmd.cc
@@ -35,7 +35,7 @@ void RunCmd::Exec(bool run_detach) {
     auto related_models_ids = modellist_handler.FindRelatedModel(model_handle_);
     if (related_models_ids.has_error() || related_models_ids.value().empty()) {
       auto result = model_service_.DownloadModel(model_handle_);
-      if(result.has_error()) {
+      if (result.has_error()) {
         CLI_LOG(result.error());
         return;
       }

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -316,7 +316,7 @@ cpp::result<std::string, std::string> ModelService::HandleUrl(
 
   if (model_entry.has_value()) {
     CLI_LOG("Model already downloaded: " << unique_model_id);
-    return cpp::fail("Please delete the model before downloading again");
+    return unique_model_id;
   }
 
   auto local_path{file_manager_utils::GetModelsContainerPath() /


### PR DESCRIPTION
## Describe Your Changes

- Return model_id instead of error if model is already downloaded

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1513

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed