### PR TITLE
chore: add model name as a parameter support during import via API

### DIFF
--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -554,6 +554,46 @@
         "tags": ["Models"]
       }
     },
+    "/v1/models/import": {
+      "post": {
+        "operationId": "ModelsController_importModel",
+        "summary": "Import model",
+        "description": "Imports a model from a specified path.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportModelRequest"
+              },
+              "example": {
+                "model": "model-id",
+                "modelPath": "/path/to/gguf",
+                "name": "model display name"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model is imported successfully!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportModelResponse"
+                },
+                "example": {
+                  "message": "Model is imported successfully!",
+                  "modelHandle": "model-id",
+                  "result": "OK"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Models"]
+      }
+    },
     "/v1/threads": {
       "post": {
         "operationId": "ThreadsController_create",
@@ -1802,6 +1842,43 @@
             "description": "A downloaded model name."
           }
         }
+      },
+      "ImportModelRequest": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The unique identifier of the model."
+          },
+          "modelPath": {
+            "type": "string",
+            "description": "The file path to the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the model."
+          }
+        },
+        "required": ["model", "modelPath"]
+      },
+      "ImportModelResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Success message."
+          },
+          "modelHandle": {
+            "type": "string",
+            "description": "The unique identifier of the imported model."
+          },
+          "result": {
+            "type": "string",
+            "description": "Result status.",
+            "example": "OK"
+          }
+        },
+        "required": ["message", "modelHandle", "result"]
       },
       "CommonResponseDto": {
         "type": "object",

--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -1700,6 +1700,15 @@
                 "value": "my-custom-model-id"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name which will be used to overwrite the model name.",
+            "examples": [
+              {
+                "value": "my-custom-model-name"
+              }
+            ]
           }
         }
       },

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -312,6 +312,7 @@ void Models::ImportModel(
   }
   auto modelHandle = (*(req->getJsonObject())).get("model", "").asString();
   auto modelPath = (*(req->getJsonObject())).get("modelPath", "").asString();
+  auto modelName = (*(req->getJsonObject())).get("name", "").asString();
   config::GGUFHandler gguf_handler;
   config::YamlHandler yaml_handler;
   cortex::db::Models modellist_utils_obj;
@@ -333,6 +334,7 @@ void Models::ImportModel(
     config::ModelConfig model_config = gguf_handler.GetModelConfig();
     model_config.files.push_back(modelPath);
     model_config.model = modelHandle;
+    model_config.name = modelName.empty() ? model_config.name : modelName;
     yaml_handler.UpdateModelConfig(model_config);
 
     if (modellist_utils_obj.AddModelEntry(model_entry).value()) {

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -33,12 +33,19 @@ void Models::PullModel(const HttpRequestPtr& req,
     desired_model_id = id;
   }
 
+  std::optional<std::string> desired_model_name = std::nullopt;
+  auto name_value = (*(req->getJsonObject())).get("name", "").asString();
+
+  if (!name_value.empty()) {
+    desired_model_name = name_value;
+  }
+
   auto handle_model_input =
       [&, model_handle]() -> cpp::result<DownloadTask, std::string> {
     CTL_INF("Handle model input, model handle: " + model_handle);
     if (string_utils::StartsWith(model_handle, "https")) {
-      return model_service_->HandleDownloadUrlAsync(model_handle,
-                                                    desired_model_id);
+      return model_service_->HandleDownloadUrlAsync(
+          model_handle, desired_model_id, desired_model_name);
     } else if (model_handle.find(":") != std::string::npos) {
       auto model_and_branch = string_utils::SplitBy(model_handle, ":");
       return model_service_->DownloadModelFromCortexsoAsync(

--- a/engine/e2e-test/test_api_model_import.py
+++ b/engine/e2e-test/test_api_model_import.py
@@ -18,5 +18,25 @@ class TestApiModelImport:
     def test_model_import_should_be_success(self):
         body_json = {'model': 'tinyllama:gguf',
                      'modelPath': '/path/to/local/gguf'}
-        response = requests.post("http://localhost:3928/models/import", json = body_json)              
-        assert response.status_code == 200      
+        response = requests.post("http://localhost:3928/models/import", json=body_json)              
+        assert response.status_code == 200
+
+    @pytest.mark.skipif(True, reason="Expensive test. Only test when you have local gguf file.")
+    def test_model_import_with_name_should_be_success(self):
+        body_json = {'model': 'tinyllama:gguf',
+                     'modelPath': '/path/to/local/gguf',
+                     'name': 'test_model'}
+        response = requests.post("http://localhost:3928/models/import", json=body_json)
+        assert response.status_code == 200
+
+    def test_model_import_with_invalid_path_should_fail(self):
+        body_json = {'model': 'tinyllama:gguf',
+                     'modelPath': '/invalid/path/to/gguf'}
+        response = requests.post("http://localhost:3928/models/import", json=body_json)
+        assert response.status_code == 400
+
+    def test_model_import_with_missing_model_should_fail(self):
+        body_json = {'modelPath': '/path/to/local/gguf'}
+        response = requests.post("http://localhost:3928/models/import", json=body_json)
+        print(response)
+        assert response.status_code == 409

--- a/engine/e2e-test/test_api_model_pull_direct_url.py
+++ b/engine/e2e-test/test_api_model_pull_direct_url.py
@@ -53,3 +53,22 @@ class TestApiModelPullDirectUrl:
             get_model_response.json()["model"]
             == "TheBloke:TinyLlama-1.1B-Chat-v0.3-GGUF:tinyllama-1.1b-chat-v0.3.Q2_K.gguf"
         )
+
+    @pytest.mark.asyncio
+    async def test_model_pull_with_direct_url_should_have_desired_name(self):
+        myobj = {
+            "model": "https://huggingface.co/afrideva/zephyr-smol_llama-100m-sft-full-GGUF/blob/main/zephyr-smol_llama-100m-sft-full.q2_k.gguf",
+            "name": "smol_llama_100m"
+        }
+        response = requests.post("http://localhost:3928/models/pull", json=myobj)
+        assert response.status_code == 200
+        await wait_for_websocket_download_success_event(timeout=None)
+        get_model_response = requests.get(
+            "http://127.0.0.1:3928/models/afrideva:zephyr-smol_llama-100m-sft-full-GGUF:zephyr-smol_llama-100m-sft-full.q2_k.gguf"
+        )
+        assert get_model_response.status_code == 200
+        print(get_model_response.json()["name"])
+        assert (
+            get_model_response.json()["name"]
+            == "smol_llama_100m"
+        )

--- a/engine/e2e-test/test_api_model_pull_direct_url.py
+++ b/engine/e2e-test/test_api_model_pull_direct_url.py
@@ -21,7 +21,7 @@ class TestApiModelPullDirectUrl:
             [
                 "models",
                 "delete",
-                "TheBloke:TinyLlama-1.1B-Chat-v0.3-GGUF:tinyllama-1.1b-chat-v0.3.Q2_K.gguf",
+                "afrideva:zephyr-smol_llama-100m-sft-full-GGUF:zephyr-smol_llama-100m-sft-full.q2_k.gguf",
             ],
         )
         yield
@@ -32,7 +32,7 @@ class TestApiModelPullDirectUrl:
             [
                 "models",
                 "delete",
-                "TheBloke:TinyLlama-1.1B-Chat-v0.3-GGUF:tinyllama-1.1b-chat-v0.3.Q2_K.gguf",
+                "afrideva:zephyr-smol_llama-100m-sft-full-GGUF:zephyr-smol_llama-100m-sft-full.q2_k.gguf",
             ],
         )
         stop_server()
@@ -40,18 +40,18 @@ class TestApiModelPullDirectUrl:
     @pytest.mark.asyncio
     async def test_model_pull_with_direct_url_should_be_success(self):
         myobj = {
-            "model": "https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v0.3-GGUF/blob/main/tinyllama-1.1b-chat-v0.3.Q2_K.gguf"
+            "model": "https://huggingface.co/afrideva/zephyr-smol_llama-100m-sft-full-GGUF/blob/main/zephyr-smol_llama-100m-sft-full.q2_k.gguf"
         }
         response = requests.post("http://localhost:3928/models/pull", json=myobj)
         assert response.status_code == 200
         await wait_for_websocket_download_success_event(timeout=None)
         get_model_response = requests.get(
-            "http://127.0.0.1:3928/models/TheBloke:TinyLlama-1.1B-Chat-v0.3-GGUF:tinyllama-1.1b-chat-v0.3.Q2_K.gguf"
+            "http://127.0.0.1:3928/models/afrideva:zephyr-smol_llama-100m-sft-full-GGUF:zephyr-smol_llama-100m-sft-full.q2_k.gguf"
         )
         assert get_model_response.status_code == 200
         assert (
             get_model_response.json()["model"]
-            == "TheBloke:TinyLlama-1.1B-Chat-v0.3-GGUF:tinyllama-1.1b-chat-v0.3.Q2_K.gguf"
+            == "afrideva:zephyr-smol_llama-100m-sft-full-GGUF:zephyr-smol_llama-100m-sft-full.q2_k.gguf"
         )
 
     @pytest.mark.asyncio

--- a/engine/services/model_service.h
+++ b/engine/services/model_service.h
@@ -39,7 +39,7 @@ class ModelService {
       std::shared_ptr<DownloadService> download_service,
       std::shared_ptr<services::InferenceService> inference_service)
       : download_service_{download_service},
-        inference_svc_(inference_service) {};
+        inference_svc_(inference_service){};
 
   /**
    * Return model id if download successfully
@@ -81,7 +81,8 @@ class ModelService {
   cpp::result<std::string, std::string> HandleUrl(const std::string& url);
 
   cpp::result<DownloadTask, std::string> HandleDownloadUrlAsync(
-      const std::string& url, std::optional<std::string> temp_model_id);
+      const std::string& url, std::optional<std::string> temp_model_id,
+      std::optional<std::string> temp_name);
 
  private:
   /**


### PR DESCRIPTION
## Describe Your Changes
- When importing a model via API from Jan, the model's display name is extracted from the GGUF metadata but most of them are poorly defined. E.g. just `model` or blank space. This chore update allow clients to decide the model name. Also provided the missing API doc schema.

1. When making a request to import a model, I should be able to provide it's name.
<img width="681" alt="Screenshot 2024-10-31 at 22 05 27" src="https://github.com/user-attachments/assets/ba70391a-042b-42a3-ad28-07293b709697">

2. The imported model should have the name updated accordingly
<img width="1266" alt="Screenshot 2024-10-31 at 22 05 20" src="https://github.com/user-attachments/assets/5209ec51-8cbd-4eb6-b360-245c81bc043f">

3. I should be able to see Model Import API on the scalar API reference
<img width="1189" alt="Screenshot 2024-10-31 at 22 38 05" src="https://github.com/user-attachments/assets/61c5a991-ee98-4f49-8192-f9ce014fc72d">


## Changes made

1. In `models.cc`:
   - A new variable `modelName` is extracted from the JSON request.
   - A check is added to throw an error if `modelHandle` is empty.
   - The `name` field of `model_config` is updated with `modelName` if it's not empty.

2. In `test_api_model_import.py`:
   - The existing test case is slightly modified (changing `json = body_json` to `json=body_json`).
   - Three new test cases are added:
     a. Testing model import with a custom name (marked to skip by default).
     b. Testing model import with an invalid path (expected to fail).
     c. Testing model import with a missing model (expected to fail).
   
3. A new endpoint `/v1/models/import` is added:
   - It's a POST request for importing a model.
   - The operation ID is "ModelsController_importModel".
   - It requires a request body with a schema referencing "#/components/schemas/ImportModelRequest".
   - The response for a successful import (200 status) includes a schema referencing "#/components/schemas/ImportModelResponse".

4. Two new schemas are added:
   - `ImportModelRequest`:
     - Contains properties for "model" (identifier), "modelPath" (file path), and "name" (display name).
     - "model" and "modelPath" are required fields.

   - `ImportModelResponse`:
     - Contains properties for "message" (success message), "modelHandle" (unique identifier), and "result" (status).
     - All fields are required.

5. Pull with a desired name
<img width="997" alt="Screenshot 2024-11-01 at 10 39 27" src="https://github.com/user-attachments/assets/3a9417be-6b16-4670-9b9b-fb4d7e390325">
<img width="222" alt="Screenshot 2024-11-01 at 10 39 56" src="https://github.com/user-attachments/assets/30340486-511e-4f3a-804b-cc5b7ed3f046">

6. Update Model Pull API doc
<img width="1615" alt="Screenshot 2024-11-01 at 10 45 18" src="https://github.com/user-attachments/assets/59359f5f-1790-4619-8a02-9f5a36760323">


These changes enhance the model import functionality by allowing custom names and adding more robust error checking. The new test cases improve the coverage of the API's behavior under different scenarios. Also provided the missing API doc, with appropriate request and response structures defined in the OpenAPI specification.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed