### PR TITLE
fix: server uploads to temporary directory

### DIFF
--- a/engine/main.cc
+++ b/engine/main.cc
@@ -103,7 +103,7 @@ void RunServer(std::optional<int> port) {
   auto pm_ctl = std::make_shared<ProcessManager>();
   auto server_ctl = std::make_shared<inferences::server>(inference_svc);
 
-    drogon::app().registerController(engine_ctl);
+  drogon::app().registerController(engine_ctl);
   drogon::app().registerController(model_ctl);
   drogon::app().registerController(event_ctl);
   drogon::app().registerController(pm_ctl);

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -103,11 +103,14 @@ void RunServer(std::optional<int> port) {
   auto pm_ctl = std::make_shared<ProcessManager>();
   auto server_ctl = std::make_shared<inferences::server>(inference_svc);
 
-  drogon::app().registerController(engine_ctl);
+    drogon::app().registerController(engine_ctl);
   drogon::app().registerController(model_ctl);
   drogon::app().registerController(event_ctl);
   drogon::app().registerController(pm_ctl);
   drogon::app().registerController(server_ctl);
+
+  auto upload_path = std::filesystem::temp_directory_path() / "cortex-uploads";
+  drogon::app().setUploadPath(upload_path.string());
 
   LOG_INFO << "Server started, listening at: " << config.apiServerHost << ":"
            << config.apiServerPort;

--- a/engine/templates/linux/postinst
+++ b/engine/templates/linux/postinst
@@ -9,3 +9,4 @@ fi
 USER_TO_RUN_AS=${SUDO_USER:-$(whoami)}
 echo "Download cortex.llamacpp engines by default for user $USER_TO_RUN_AS"
 sudo -u $USER_TO_RUN_AS env PATH=$PATH:/usr/lib/wsl/lib /usr/bin/$DESTINATION_BINARY_NAME engines install llama-cpp
+sudo -u $USER_TO_RUN_AS env PATH=$PATH:/usr/lib/wsl/lib /usr/bin/$DESTINATION_BINARY_NAME stop

--- a/engine/templates/macos/postinstall
+++ b/engine/templates/macos/postinstall
@@ -11,8 +11,14 @@ fi
 
 USER_TO_RUN_AS=$(stat -f "%Su" /dev/console)
 
+echo "Start server before downloading server for user $USER_TO_RUN_AS"
+sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME start
+
 echo "Download cortex.llamacpp engines by default for user $USER_TO_RUN_AS"
 sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME engines install llama-cpp
+
+echo "Stop server"
+sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME stop
 
 sudo chown -R $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME"
 sudo chown $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME"

--- a/engine/templates/macos/postinstall_local
+++ b/engine/templates/macos/postinstall_local
@@ -11,14 +11,8 @@ fi
 
 USER_TO_RUN_AS=$(stat -f "%Su" /dev/console)
 
-echo "Start server before downloading server for user $USER_TO_RUN_AS"
-sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME start
-
 echo "Download cortex.llamacpp engines by default for user $USER_TO_RUN_AS"
 sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME engines install llama-cpp -s ./dependencies
-
-echo "Stop server"
-sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME stop
 
 sudo chown -R $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME"
 sudo chown $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME"

--- a/engine/templates/macos/postinstall_local
+++ b/engine/templates/macos/postinstall_local
@@ -11,8 +11,14 @@ fi
 
 USER_TO_RUN_AS=$(stat -f "%Su" /dev/console)
 
+echo "Start server before downloading server for user $USER_TO_RUN_AS"
+sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME start
+
 echo "Download cortex.llamacpp engines by default for user $USER_TO_RUN_AS"
 sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME engines install llama-cpp -s ./dependencies
+
+echo "Stop server"
+sudo -u $USER_TO_RUN_AS /usr/local/bin/$DESTINATION_BINARY_NAME stop
 
 sudo chown -R $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$DATA_FOLDER_NAME"
 sudo chown $USER_TO_RUN_AS:staff "/Users/$USER_TO_RUN_AS/$CONFIGURATION_FILE_NAME"

--- a/engine/templates/windows/installer-beta.iss
+++ b/engine/templates/windows/installer-beta.iss
@@ -36,7 +36,7 @@ Filename: "{app}\cortex-beta.exe"; Parameters: "stop"; StatusMsg: "Stopping cort
 procedure AddToUserPathAndInstallEngines;
 var
   ExpandedAppDir: String;
-  CmdLine, CortexInstallCmd: String;
+  CmdLine, CortexInstallCmd, CortexStopServerCmd: String;
   ResultCode: Integer;
   i: Integer;
   SkipPostInstall: Boolean;

--- a/engine/templates/windows/installer-beta.iss
+++ b/engine/templates/windows/installer-beta.iss
@@ -84,6 +84,10 @@ begin
   CortexInstallCmd := Format('"%s\cortex-beta.exe" engines install llama-cpp', [ExpandedAppDir]);
   Exec('cmd.exe', '/C ' + CortexInstallCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
+  // Stop server
+  CortexStopServerCmd := Format('"%s\cortex-nightly.exe" stop', [ExpandedAppDir]);
+  Exec('cmd.exe', '/C ' + CortexStopServerCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+
   // Set the progress bar to 90% after downloading the engine
   WizardForm.ProgressGauge.Position := 90;
   WizardForm.ProgressGauge.Update;

--- a/engine/templates/windows/installer-nightly.iss
+++ b/engine/templates/windows/installer-nightly.iss
@@ -84,6 +84,10 @@ begin
   CortexInstallCmd := Format('"%s\cortex-nightly.exe" engines install llama-cpp', [ExpandedAppDir]);
   Exec('cmd.exe', '/C ' + CortexInstallCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
+  // Stop server
+  CortexStopServerCmd := Format('"%s\cortex-nightly.exe" stop', [ExpandedAppDir]);
+  Exec('cmd.exe', '/C ' + CortexStopServerCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+
   // Set the progress bar to 90% after downloading the engine
   WizardForm.ProgressGauge.Position := 90;
   WizardForm.ProgressGauge.Update;

--- a/engine/templates/windows/installer-nightly.iss
+++ b/engine/templates/windows/installer-nightly.iss
@@ -36,7 +36,7 @@ Filename: "{app}\cortex-nightly.exe"; Parameters: "stop"; StatusMsg: "Stopping c
 procedure AddToUserPathAndInstallEngines;
 var
   ExpandedAppDir: String;
-  CmdLine, CortexInstallCmd: String;
+  CmdLine, CortexInstallCmd, CortexStopServerCmd: String;
   ResultCode: Integer;
   i: Integer;
   SkipPostInstall: Boolean;

--- a/engine/templates/windows/installer.iss
+++ b/engine/templates/windows/installer.iss
@@ -84,6 +84,10 @@ begin
   CortexInstallCmd := Format('"%s\cortex.exe" engines install llama-cpp', [ExpandedAppDir]);
   Exec('cmd.exe', '/C ' + CortexInstallCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
+  // Stop server
+  CortexStopServerCmd := Format('"%s\cortex-nightly.exe" stop', [ExpandedAppDir]);
+  Exec('cmd.exe', '/C ' + CortexStopServerCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+
   // Set the progress bar to 90% after downloading the engine
   WizardForm.ProgressGauge.Position := 90;
   WizardForm.ProgressGauge.Update;

--- a/engine/templates/windows/installer.iss
+++ b/engine/templates/windows/installer.iss
@@ -36,7 +36,7 @@ Filename: "{app}\cortex.exe"; Parameters: "stop"; StatusMsg: "Stopping cortexcpp
 procedure AddToUserPathAndInstallEngines;
 var
   ExpandedAppDir: String;
-  CmdLine, CortexInstallCmd: String;
+  CmdLine, CortexInstallCmd, CortexStopServerCmd: String;
   ResultCode: Integer;
   i: Integer;
   SkipPostInstall: Boolean;


### PR DESCRIPTION
## Describe Your Changes

- `Drogon` does not allow us to disable uploads folder. Set it to temporary folder to not spam log when does not have permission to create uploads folder.
- Start server before installing engine for macOS network installer
- Stop server for network installer
## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed