### PR TITLE
chore: return model size after pulled

### DIFF
--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -3434,6 +3434,11 @@
             "description": "To enable mmap, default is true",
             "example": true
           },
+          "size": {
+            "type": "number",
+            "description": "The model file size in bytes",
+            "example": 1073741824
+          },
           "engine": {
             "type": "string",
             "description": "The engine to use.",

--- a/engine/config/model_config.h
+++ b/engine/config/model_config.h
@@ -58,6 +58,7 @@ struct ModelConfig {
   bool ignore_eos = false;
   int n_probs = 0;
   int min_keep = 0;
+  uint64_t size = 0;
   std::string grammar;
 
   void FromJson(const Json::Value& json) {
@@ -70,6 +71,8 @@ struct ModelConfig {
     //   model = json["model"].asString();
     if (json.isMember("version"))
       version = json["version"].asString();
+    if (json.isMember("size"))
+      size = json["size"].asUInt64();
 
     if (json.isMember("stop") && json["stop"].isArray()) {
       stop.clear();
@@ -176,6 +179,7 @@ struct ModelConfig {
     obj["name"] = name;
     obj["model"] = model;
     obj["version"] = version;
+    obj["size"] = size;
 
     Json::Value stop_array(Json::arrayValue);
     for (const auto& s : stop) {
@@ -269,6 +273,7 @@ struct ModelConfig {
     oss << format_utils::print_comment("END REQUIRED");
     oss << format_utils::print_comment("BEGIN OPTIONAL");
 
+    oss << format_utils::print_float("size", size);
     oss << format_utils::print_bool("stream", stream);
     oss << format_utils::print_float("top_p", top_p);
     oss << format_utils::print_float("temperature", temperature);

--- a/engine/config/yaml_config.cc
+++ b/engine/config/yaml_config.cc
@@ -75,6 +75,8 @@ void YamlHandler::ModelConfigFromYaml() {
       tmp.model = yaml_node_["model"].as<std::string>();
     if (yaml_node_["version"])
       tmp.version = yaml_node_["version"].as<std::string>();
+    if (yaml_node_["size"])
+      tmp.size = yaml_node_["size"].as<uint64_t>();
     if (yaml_node_["engine"])
       tmp.engine = yaml_node_["engine"].as<std::string>();
     if (yaml_node_["prompt_template"]) {
@@ -266,6 +268,9 @@ void YamlHandler::UpdateModelConfig(ModelConfig new_model_config) {
     if (!model_config_.grammar.empty())
       yaml_node_["grammar"] = model_config_.grammar;
 
+    if (!std::isnan(static_cast<double>(model_config_.size)))
+      yaml_node_["size"] = model_config_.size;
+
     yaml_node_["created"] = std::time(nullptr);
   } catch (const std::exception& e) {
     std::cerr << "Error when update model config : " << e.what() << std::endl;
@@ -318,6 +323,7 @@ void YamlHandler::WriteYamlFile(const std::string& file_path) const {
     outFile << "# END REQUIRED\n";
     outFile << "\n";
     outFile << "# BEGIN OPTIONAL\n";
+    outFile << format_utils::writeKeyValue("size", yaml_node_["size"]);
     outFile << format_utils::writeKeyValue("stream", yaml_node_["stream"],
                                            "Default true?");
     outFile << format_utils::writeKeyValue("top_p", yaml_node_["top_p"],

--- a/engine/config/yaml_config.cc
+++ b/engine/config/yaml_config.cc
@@ -268,8 +268,7 @@ void YamlHandler::UpdateModelConfig(ModelConfig new_model_config) {
     if (!model_config_.grammar.empty())
       yaml_node_["grammar"] = model_config_.grammar;
 
-    if (!std::isnan(static_cast<double>(model_config_.size)))
-      yaml_node_["size"] = model_config_.size;
+    yaml_node_["size"] = model_config_.size;
 
     yaml_node_["created"] = std::time(nullptr);
   } catch (const std::exception& e) {


### PR DESCRIPTION
## Describe Your Changes

- Clients like Jan view the model's size as metadata for local models. This helps users determine compatibility with their computer specs.
- This PR saves the model's size as metadata (in bytes).

`model.yaml`
![Screenshot 2024-11-04 at 14 54 03](https://github.com/user-attachments/assets/d3c7987f-ef02-43d9-9e8f-71ba1d99f71d)

`API Response body`
<img width="184" alt="Screenshot 2024-11-04 at 14 58 06" src="https://github.com/user-attachments/assets/9b626be8-89ef-4aeb-9b52-4f0e3d9b2e9a">

API Playground
![image](https://github.com/user-attachments/assets/951c1b5f-5021-45ba-9026-949268ef35f9)


## Changes made

The provided git diff introduces changes primarily focused on tracking and handling a new attribute called `size` within the `ModelConfig` struct. Here are the key changes summarized:

1. **ModelConfig Struct Update**:
   - A new field `uint64_t size` is added to the `ModelConfig` struct to store the size of the model.
   - `FromJson` method is updated to parse the `size` attribute from JSON if present.
   - `ToJson` method is updated to include the `size` attribute in the JSON output.
   - `Print` method now prints the `size` attribute along with other attributes.

2. **YamlHandler Update**:
   - In `UpdateModelConfig`, the YAML node is updated to include the `size` of the model if it is not NaN. 
   - Likely missed the context, but casting `size` of type `uint64_t` to `double` for NaN check is unusual since `uint64_t` can't be NaN.

3. **ParseGguf Function Update**:
   - The function signature of `ParseGguf` is updated to include an optional `std::uint64_t size` parameter.
   - The `size` is set on `model_config` with a default of 0 if no `size` is provided.

4. **Model Service Update**:
   - In two functions (`HandleDownloadUrlAsync` and `HandleUrl`), after a download task is finished, the total downloaded size (`model_size`) is calculated by summing up `bytes` from all items in `finishedTask.items`.
   - `ParseGguf` is called with the computed `model_size` to ensure the size is recorded in the `ModelConfig`.

These changes enhance the system to manage and persist the size of model files across configurations and YAML updates.