### PR TITLE
chore: add model import option parameter

### DIFF
--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -642,7 +642,8 @@
               "example": {
                 "model": "model-id",
                 "modelPath": "/path/to/gguf",
-                "name": "model display name"
+                "name": "model display name",
+                "option": "symlink"
               }
             }
           }
@@ -3187,6 +3188,10 @@
           "name": {
             "type": "string",
             "description": "The display name of the model."
+          },
+          "option": {
+            "type": "string",
+            "description": "Import options such as symlink or copy."
           }
         },
         "required": ["model", "modelPath"]

--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -3191,7 +3191,8 @@
           },
           "option": {
             "type": "string",
-            "description": "Import options such as symlink or copy."
+            "description": "Import options such as symlink or copy.",
+            "enum": ["symlink", "copy"]
           }
         },
         "required": ["model", "modelPath"]

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -350,7 +350,7 @@ void Models::ImportModel(
       std::filesystem::copy_file(
           modelPath, file_path,
           std::filesystem::copy_options::update_existing);
-      model_config.files.push_back(file_path);
+      model_config.files.push_back(file_path.string());
     } else {
       model_config.files.push_back(modelPath);
     }

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -343,7 +343,7 @@ void Models::ImportModel(
     config::ModelConfig model_config = gguf_handler.GetModelConfig();
     // There are 2 options: symlink and copy
     if (option == "copy") {
-      // Move GGUF file to the destination path
+      // Copy GGUF file to the destination path
       std::filesystem::path file_path =
           std::filesystem::path(model_yaml_path).parent_path() /
           std::filesystem::path(modelPath).filename();

--- a/engine/e2e-test/test_api_model_import.py
+++ b/engine/e2e-test/test_api_model_import.py
@@ -29,6 +29,21 @@ class TestApiModelImport:
         response = requests.post("http://localhost:3928/models/import", json=body_json)
         assert response.status_code == 200
 
+    @pytest.mark.skipif(False, reason="Expensive test. Only test when you have local gguf file.")
+    def test_model_import_with_name_should_be_success(self):
+        body_json = {'model': 'testing-model',
+                     'modelPath': '/path/to/local/gguf',
+                     'name': 'test_model',
+                     'option': 'copy'}
+        response = requests.post("http://localhost:3928/models/import", json=body_json)
+        assert response.status_code == 200
+        # Test imported path
+        response = requests.get("http://localhost:3928/models/testing-model")
+        assert response.status_code == 200
+        # Since this is a dynamic test - require actual file path
+        # it's not safe to assert with the gguf file name
+        assert response.json()['files'][0] != '/path/to/local/gguf'
+
     def test_model_import_with_invalid_path_should_fail(self):
         body_json = {'model': 'tinyllama:gguf',
                      'modelPath': '/invalid/path/to/gguf'}

--- a/engine/e2e-test/test_api_model_import.py
+++ b/engine/e2e-test/test_api_model_import.py
@@ -29,7 +29,7 @@ class TestApiModelImport:
         response = requests.post("http://localhost:3928/models/import", json=body_json)
         assert response.status_code == 200
 
-    @pytest.mark.skipif(False, reason="Expensive test. Only test when you have local gguf file.")
+    @pytest.mark.skipif(True, reason="Expensive test. Only test when you have local gguf file.")
     def test_model_import_with_name_should_be_success(self):
         body_json = {'model': 'testing-model',
                      'modelPath': '/path/to/local/gguf',


### PR DESCRIPTION
## Describe Your Changes
Users also wanted to import the model using the copy option instead of a symlink. When the original model file was deleted, the model broke in symlink mode.

![Screenshot 2024-11-04 at 16 57 01](https://github.com/user-attachments/assets/d7a073ad-6c04-47eb-b5d9-c62e1880fdf6)

## Changes made
The git diff shows modifications in three files: `cortex.json`, `models.cc`, and `test_api_model_import.py`. Here's a brief summary of the changes:

1. **`cortex.json` (OpenAPI definition file):**
   - A new field `"option": "symlink"` was added to an example JSON object.
   - A new property `"option"` was added to the JSON schema, with type `"string"` and description `"Import options such as symlink or copy."`.

2. **`models.cc` (Model controller in C++):**
   - Included the `<filesystem>` header to use file system operations.
   - Extracted a new field `option` from the request JSON, with a default value of `"symlink"`.
   - Implemented logic in `ImportModel` to handle model file import based on the `option`. If `option` is `"copy"`, it uses `std::filesystem::copy_file` to copy the GGUF file to the destination. Otherwise, it just adds the current path to `model_config.files`.

3. **`test_api_model_import.py` (End-to-end tests for model import):**
   - Added a new test method `test_model_import_with_name_should_be_success`.
   - This test sends a POST request to import a model with `option` set to `"copy"`.
   - It verifies that the response is successful and checks that the imported file's path is not the original path, assuming it must be copied to a new location.

These changes add flexibility to the model import process, allowing for different import methods (copy or symlink). The tests were updated to verify this new functionality.