### PR TITLE
chore: update model's size on import

### DIFF
--- a/engine/config/gguf_parser.cc
+++ b/engine/config/gguf_parser.cc
@@ -71,12 +71,8 @@ void GGUFHandler::OpenFile(const std::string& file_path) {
   CloseHandle(file_handle_);
 
 #else
-  uintmax_t file_size_ = std::filesystem::file_size(file_path);
-  if (file_size_ == -1) {
-    perror("Error getting file size");
-    // close(fd);
-    throw std::runtime_error("Failed to get file size");
-  }
+  file_size_ = std::filesystem::file_size(file_path);
+ 
   int file_descriptor = open(file_path.c_str(), O_RDONLY);
   // Memory-map the file
   data_ = static_cast<uint8_t*>(

--- a/engine/config/gguf_parser.cc
+++ b/engine/config/gguf_parser.cc
@@ -71,24 +71,13 @@ void GGUFHandler::OpenFile(const std::string& file_path) {
   CloseHandle(file_handle_);
 
 #else
-  FILE* fd = fopen(file_path.c_str(), "rb");
-  if (!fd) {
-    perror("Error opening file");
-    throw std::runtime_error("Failed to open file");
-  }
-
-  // Get file size
-  // file_size_ = lseek(fd, 0, SEEK_END);
-  fseek(fd, 0, SEEK_END);  // move file pointer to end of file
-  file_size_ = ftell(fd);  // get the file size, in bytes
-  fclose(fd);
+  auto file_size = std::filesystem::file_size(file_path);
   if (file_size_ == -1) {
     perror("Error getting file size");
     // close(fd);
     throw std::runtime_error("Failed to get file size");
   }
   int file_descriptor = open(file_path.c_str(), O_RDONLY);
-  ;
   // Memory-map the file
   data_ = static_cast<uint8_t*>(
       mmap(nullptr, file_size_, PROT_READ, MAP_PRIVATE, file_descriptor, 0));

--- a/engine/config/gguf_parser.cc
+++ b/engine/config/gguf_parser.cc
@@ -71,7 +71,7 @@ void GGUFHandler::OpenFile(const std::string& file_path) {
   CloseHandle(file_handle_);
 
 #else
-  auto file_size = std::filesystem::file_size(file_path);
+  uintmax_t file_size_ = std::filesystem::file_size(file_path);
   if (file_size_ == -1) {
     perror("Error getting file size");
     // close(fd);

--- a/engine/config/gguf_parser.cc
+++ b/engine/config/gguf_parser.cc
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #ifdef _WIN32
 #include <io.h>

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -352,11 +352,11 @@ void Models::ImportModel(
           modelPath, file_path,
           std::filesystem::copy_options::update_existing);
       model_config.files.push_back(file_path.string());
-      auto size = std::filesystem::file_size(file_path);
+      uintmax_t size = std::filesystem::file_size(file_path);
       model_config.size = size;
     } else {
       model_config.files.push_back(modelPath);
-      auto size = std::filesystem::file_size(modelPath);
+      uintmax_t size = std::filesystem::file_size(modelPath);
       model_config.size = size;
     }
     model_config.model = modelHandle;

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -1,5 +1,6 @@
 #include "database/models.h"
 #include <drogon/HttpTypes.h>
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include "config/gguf_parser.h"
@@ -351,8 +352,12 @@ void Models::ImportModel(
           modelPath, file_path,
           std::filesystem::copy_options::update_existing);
       model_config.files.push_back(file_path.string());
+      auto size = std::filesystem::file_size(file_path);
+      model_config.size = size;
     } else {
       model_config.files.push_back(modelPath);
+      auto size = std::filesystem::file_size(modelPath);
+      model_config.size = size;
     }
     model_config.model = modelHandle;
     model_config.name = modelName.empty() ? model_config.name : modelName;

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -1,6 +1,5 @@
 #include "database/models.h"
 #include <drogon/HttpTypes.h>
-#include <cstdint>
 #include <filesystem>
 #include <optional>
 #include "config/gguf_parser.h"
@@ -352,11 +351,11 @@ void Models::ImportModel(
           modelPath, file_path,
           std::filesystem::copy_options::update_existing);
       model_config.files.push_back(file_path.string());
-      uintmax_t size = std::filesystem::file_size(file_path);
+      auto size = std::filesystem::file_size(file_path);
       model_config.size = size;
     } else {
       model_config.files.push_back(modelPath);
-      uintmax_t size = std::filesystem::file_size(modelPath);
+      auto size = std::filesystem::file_size(modelPath);
       model_config.size = size;
     }
     model_config.model = modelHandle;

--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -1,3 +1,4 @@
+#include "download_service.h"
 #include <curl/curl.h>
 #include <httplib.h>
 #include <stdio.h>
@@ -6,7 +7,6 @@
 #include <optional>
 #include <ostream>
 #include <utility>
-#include "download_service.h"
 #include "utils/format_utils.h"
 #include "utils/huggingface_utils.h"
 #include "utils/logging_utils.h"
@@ -147,7 +147,8 @@ cpp::result<bool, std::string> DownloadService::Download(
   std::string mode = "wb";
   if (std::filesystem::exists(download_item.localPath) &&
       download_item.bytes.has_value()) {
-    curl_off_t existing_file_size = GetLocalFileSize(download_item.localPath);
+    curl_off_t existing_file_size =
+        std::filesystem::file_size(download_item.localPath);
     if (existing_file_size == -1) {
       CLI_LOG("Cannot get file size: " << download_item.localPath.string()
                                        << " . Start download over!");
@@ -204,10 +205,9 @@ cpp::result<bool, std::string> DownloadService::Download(
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
   if (mode == "ab") {
-    auto local_file_size = GetLocalFileSize(download_item.localPath);
+    auto local_file_size = std::filesystem::file_size(download_item.localPath);
     if (local_file_size != -1) {
-      curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE,
-                       GetLocalFileSize(download_item.localPath));
+      curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, local_file_size);
     } else {
       CTL_ERR("Cannot get file size: " << download_item.localPath.string());
     }
@@ -224,23 +224,6 @@ cpp::result<bool, std::string> DownloadService::Download(
   curl_easy_cleanup(curl);
   return true;
 }
-
-curl_off_t DownloadService::GetLocalFileSize(
-    const std::filesystem::path& path) const {
-  auto file = fopen(path.string().c_str(), "r");
-  if (!file) {
-    return -1;
-  }
-
-  if (fseek64(file, 0, SEEK_END) != 0) {
-    return -1;
-  }
-
-  auto file_size = ftell64(file);
-  fclose(file);
-  return file_size;
-}
-
 void DownloadService::WorkerThread() {
   while (!stop_flag_) {
     DownloadTask task;

--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -147,7 +147,7 @@ cpp::result<bool, std::string> DownloadService::Download(
   std::string mode = "wb";
   if (std::filesystem::exists(download_item.localPath) &&
       download_item.bytes.has_value()) {
-    curl_off_t existing_file_size =
+    uintmax_t existing_file_size =
         std::filesystem::file_size(download_item.localPath);
     if (existing_file_size == -1) {
       CLI_LOG("Cannot get file size: " << download_item.localPath.string()
@@ -205,7 +205,7 @@ cpp::result<bool, std::string> DownloadService::Download(
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
   if (mode == "ab") {
-    auto local_file_size = std::filesystem::file_size(download_item.localPath);
+    uintmax_t local_file_size = std::filesystem::file_size(download_item.localPath);
     if (local_file_size != -1) {
       curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, local_file_size);
     } else {

--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -1,4 +1,3 @@
-#include "download_service.h"
 #include <curl/curl.h>
 #include <httplib.h>
 #include <stdio.h>

--- a/engine/services/download_service.h
+++ b/engine/services/download_service.h
@@ -90,8 +90,6 @@ class DownloadService {
       const std::string& download_id,
       const DownloadItem& download_item) noexcept;
 
-  curl_off_t GetLocalFileSize(const std::filesystem::path& path) const;
-
   std::shared_ptr<EventQueue> event_queue_;
 
   CURLM* multi_handle_;


### PR DESCRIPTION
## Describe Your Changes

This PR updates the model's size on import as supported in the pull request. It includes minor refactoring of file size extension and consolidates features using the std::filesystem API.

## Changes made
The provided `git diff` reflects several modifications across multiple files in the project. Here's a concise summary of these changes:

1. **`gguf_parser.cc`**:
   - Replaced manual file size determination with `std::filesystem::file_size` for reliability and simplicity.
   - Removed redundant code related to the old method of fetching the file size.

2. **`models.cc`**:
   - Introduced `std::filesystem::file_size` to fetch the file size when importing models, storing this size in the `model_config`.

3. **`download_service.cc` and `download_service.h`**:
   - Removed the custom `GetLocalFileSize` method and replaced its usage with `std::filesystem::file_size` for determining file sizes.
   - The `download_service.h` file had the method deleted from class specifications.
   - Adjustments were made to ensure `curl_easy_setopt` uses the new size-fetching method directly.

These changes simplify and modernize file size handling by leveraging the C++17 `<filesystem>` library.