### PR TITLE
chore: update the wrong command for running built-in models

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Once downloaded, the model `.gguf` and `model.yml` files are stored in `~\cortex
 | Model /Engine  | llama.cpp             | Command                       |
 | -------------- | --------------------- | ----------------------------- |
 | phi-3.5        | ✅                    | cortex run phi3.5             |
-| llama3.2       | ✅                    | cortex run llama3.1           |
+| llama3.2       | ✅                    | cortex run llama3.2           |
 | llama3.1       | ✅                    | cortex run llama3.1           |
 | codestral      | ✅                    | cortex run codestral          |
 | gemma2         | ✅                    | cortex run gemma2             |


### PR DESCRIPTION
## Describe Your Changes

Fixed incorrect command in README.md model table where `llama3.2` was showing the wrong command (`llama3.1` instead of `llama3.2`).

## Fixes Issues

- None

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed