### PR TITLE
fix: manually add http date header for windows

### DIFF
--- a/engine/controllers/configs.cc
+++ b/engine/controllers/configs.cc
@@ -1,4 +1,5 @@
 #include "configs.h"
+#include "utils/cortex_utils.h"
 
 void Configs::GetConfigurations(
     const HttpRequestPtr& req,
@@ -7,13 +8,13 @@ void Configs::GetConfigurations(
   if (get_config_result.has_error()) {
     Json::Value error_json;
     error_json["message"] = get_config_result.error();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error_json);
+    auto resp = cortex_utils::CreateCortexHttpJsonResponse(error_json);
     resp->setStatusCode(drogon::k400BadRequest);
     callback(resp);
     return;
   }
 
-  auto resp = drogon::HttpResponse::newHttpJsonResponse(
+  auto resp = cortex_utils::CreateCortexHttpJsonResponse(
       get_config_result.value().ToJson());
   resp->setStatusCode(drogon::k200OK);
   callback(resp);
@@ -27,7 +28,7 @@ void Configs::UpdateConfigurations(
   if (json_body == nullptr) {
     Json::Value error_json;
     error_json["message"] = "Configuration must be provided via JSON body";
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error_json);
+    auto resp = cortex_utils::CreateCortexHttpJsonResponse(error_json);
     resp->setStatusCode(drogon::k400BadRequest);
     callback(resp);
     return;
@@ -37,7 +38,7 @@ void Configs::UpdateConfigurations(
   if (update_config_result.has_error()) {
     Json::Value error_json;
     error_json["message"] = update_config_result.error();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error_json);
+    auto resp = cortex_utils::CreateCortexHttpJsonResponse(error_json);
     resp->setStatusCode(drogon::k400BadRequest);
     callback(resp);
     return;
@@ -46,7 +47,7 @@ void Configs::UpdateConfigurations(
   Json::Value root;
   root["message"] = "Configuration updated successfully";
   root["config"] = update_config_result.value().ToJson();
-  auto resp = drogon::HttpResponse::newHttpJsonResponse(root);
+  auto resp = cortex_utils::CreateCortexHttpJsonResponse(root);
   resp->setStatusCode(drogon::k200OK);
   callback(resp);
   return;

--- a/engine/controllers/swagger.cc
+++ b/engine/controllers/swagger.cc
@@ -1,5 +1,6 @@
 #include "swagger.h"
 #include "cortex_openapi.h"
+#include "utils/cortex_utils.h"
 
 constexpr auto ScalarUi = R"(
 <!doctype html>
@@ -31,7 +32,7 @@ Json::Value SwaggerController::generateOpenAPISpec() {
 void SwaggerController::serveSwaggerUI(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
-  auto resp = drogon::HttpResponse::newHttpResponse();
+  auto resp = cortex_utils::CreateCortexHttpResponse();
   resp->setBody(ScalarUi);
   resp->setContentTypeCode(drogon::CT_TEXT_HTML);
   callback(resp);
@@ -41,6 +42,6 @@ void SwaggerController::serveOpenAPISpec(
     const drogon::HttpRequestPtr& req,
     std::function<void(const drogon::HttpResponsePtr&)>&& callback) const {
   Json::Value spec = generateOpenAPISpec();
-  auto resp = drogon::HttpResponse::newHttpJsonResponse(spec);
+  auto resp = cortex_utils::CreateCortexHttpJsonResponse(spec);
   callback(resp);
 }

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -150,6 +150,8 @@ void RunServer(std::optional<int> port, bool ignore_cout) {
   LOG_INFO << "Please load your model";
 #ifndef _WIN32
   drogon::app().enableReusePort();
+#else
+  drogon::app().enableDateHeader(false);
 #endif
   drogon::app().addListener(config.apiServerHost,
                             std::stoi(config.apiServerPort));

--- a/engine/utils/cortex_utils.h
+++ b/engine/utils/cortex_utils.h
@@ -3,7 +3,9 @@
 #include <drogon/HttpResponse.h>
 #include <sys/stat.h>
 #include <algorithm>
+#include <ctime>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <ostream>
 #include <random>
@@ -24,20 +26,41 @@ inline std::string logs_folder = "./logs";
 inline std::string logs_base_name = "./logs/cortex.log";
 inline std::string logs_cli_base_name = "./logs/cortex-cli.log";
 
+// example: Mon, 25 Nov 2024 09:57:03 GMT
+inline std::string GetDateRFC1123() {
+  std::time_t now = std::time(nullptr);
+  std::tm* gmt_time = std::gmtime(&now);
+  std::ostringstream oss;
+  oss << std::put_time(gmt_time, "%a, %d %b %Y %H:%M:%S GMT");
+  return oss.str();
+}
+
 inline drogon::HttpResponsePtr CreateCortexHttpResponse() {
-  return drogon::HttpResponse::newHttpResponse();
+  auto res = drogon::HttpResponse::newHttpResponse();
+#if defined(_WIN32)
+  res->addHeader("date", GetDateRFC1123());
+#endif
+  return res;
 }
 
 inline drogon::HttpResponsePtr CreateCortexHttpJsonResponse(
     const Json::Value& data) {
-  return drogon::HttpResponse::newHttpJsonResponse(data);
+  auto res = drogon::HttpResponse::newHttpJsonResponse(data);
+#if defined(_WIN32)
+  res->addHeader("date", GetDateRFC1123());
+#endif
+  return res;
 };
 
 inline drogon::HttpResponsePtr CreateCortexStreamResponse(
     const std::function<std::size_t(char*, std::size_t)>& callback,
     const std::string& attachmentFileName = "") {
-  return drogon::HttpResponse::newStreamResponse(
+  auto res = drogon::HttpResponse::newStreamResponse(
       callback, attachmentFileName, drogon::CT_NONE, "text/event-stream");
+#if defined(_WIN32)
+  res->addHeader("date", GetDateRFC1123());
+#endif
+  return res;
 }
 
 #if defined(_WIN32)


### PR DESCRIPTION
## Describe Your Changes

- On Windows we set locale to local when convert wstring to std::string. This impacts date field in drogon http header, should add the date as specified in RFC 1123.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1722

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed