### PR TITLE
chore: fixed incorrect repository URL in the Star History chart link

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -173,4 +173,4 @@ Manual build is a process in which the developers build the software manually. T
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=janhq/cortex-cpp&type=Date)](https://star-history.com/#janhq/cortex-cpp&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=janhq/cortex.cpp&type=Date)](https://star-history.com/#janhq/cortex.cpp&Date)


### PR DESCRIPTION
## Describe Your Changes

- Fixed incorrect repository URL in the Star History chart link. Updated from `cortex-cpp` to `cortex.cpp` to match the correct repository name.

## Fixes Issues

- None

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

