### PR TITLE
fix: server start takes a long time

### DIFF
--- a/engine/cli/commands/engine_install_cmd.cc
+++ b/engine/cli/commands/engine_install_cmd.cc
@@ -37,7 +37,8 @@ bool EngineInstallCmd::Exec(const std::string& engine,
     dp.Connect(host_, port_);
     // engine can be small, so need to start ws first
     auto dp_res = std::async(std::launch::deferred, [&dp] {
-      bool need_cuda_download = !system_info_utils::GetCudaVersion().empty();
+      bool need_cuda_download =
+          !system_info_utils::GetDriverAndCudaVersion().second.empty();
       if (need_cuda_download) {
         return dp.Handle({DownloadType::Engine, DownloadType::CudaToolkit});
       } else {
@@ -149,7 +150,8 @@ bool EngineInstallCmd::Exec(const std::string& engine,
   dp.Connect(host_, port_);
   // engine can be small, so need to start ws first
   auto dp_res = std::async(std::launch::deferred, [&dp] {
-    bool need_cuda_download = !system_info_utils::GetCudaVersion().empty();
+    bool need_cuda_download =
+        !system_info_utils::GetDriverAndCudaVersion().second.empty();
     if (need_cuda_download) {
       return dp.Handle({DownloadType::Engine, DownloadType::CudaToolkit});
     } else {

--- a/engine/cli/commands/engine_install_cmd.h
+++ b/engine/cli/commands/engine_install_cmd.h
@@ -14,7 +14,8 @@ class EngineInstallCmd {
         port_(port),
         show_menu_(show_menu),
         hw_inf_{.sys_inf = system_info_utils::GetSystemInfo(),
-                .cuda_driver_version = system_info_utils::GetCudaVersion()} {};
+                .cuda_driver_version =
+                    system_info_utils::GetDriverAndCudaVersion().second} {};
 
   bool Exec(const std::string& engine, const std::string& version = "latest",
             const std::string& src = "");

--- a/engine/cli/commands/engine_update_cmd.cc
+++ b/engine/cli/commands/engine_update_cmd.cc
@@ -25,7 +25,8 @@ bool EngineUpdateCmd::Exec(const std::string& host, int port,
   dp.Connect(host, port);
   // engine can be small, so need to start ws first
   auto dp_res = std::async(std::launch::deferred, [&dp] {
-    bool need_cuda_download = !system_info_utils::GetCudaVersion().empty();
+    bool need_cuda_download =
+        !system_info_utils::GetDriverAndCudaVersion().second.empty();
     if (need_cuda_download) {
       return dp.Handle({DownloadType::Engine, DownloadType::CudaToolkit});
     } else {

--- a/engine/cli/commands/server_start_cmd.cc
+++ b/engine/cli/commands/server_start_cmd.cc
@@ -8,7 +8,7 @@ namespace commands {
 
 namespace {
 bool TryConnectToServer(const std::string& host, int port) {
-  constexpr const auto kMaxRetry = 3u;
+  constexpr const auto kMaxRetry = 4u;
   auto count = 0u;
   // Check if server is started
   while (true) {

--- a/engine/services/engine_service.h
+++ b/engine/services/engine_service.h
@@ -62,7 +62,8 @@ class EngineService : public EngineServiceI {
   explicit EngineService(std::shared_ptr<DownloadService> download_service)
       : download_service_{download_service},
         hw_inf_{.sys_inf = system_info_utils::GetSystemInfo(),
-                .cuda_driver_version = system_info_utils::GetCudaVersion()} {}
+                .cuda_driver_version =
+                    system_info_utils::GetDriverAndCudaVersion().second} {}
 
   std::vector<EngineInfo> GetEngineInfoList() const;
 

--- a/engine/services/hardware_service.cc
+++ b/engine/services/hardware_service.cc
@@ -16,7 +16,7 @@ namespace services {
 
 namespace {
 bool TryConnectToServer(const std::string& host, int port) {
-  constexpr const auto kMaxRetry = 3u;
+  constexpr const auto kMaxRetry = 4u;
   auto count = 0u;
   // Check if server is started
   while (true) {
@@ -292,7 +292,7 @@ void HardwareService::UpdateHardwareInfos() {
   }
 
 #if defined(_WIN32) || defined(_WIN64) || defined(__linux__)
-  if (system_info_utils::IsNvidiaSmiAvailable()) {
+  if (!gpus.empty()) {
     const char* value = std::getenv("CUDA_VISIBLE_DEVICES");
     if (value) {
       LOG_INFO << "CUDA_VISIBLE_DEVICES: " << value;

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -11,12 +11,11 @@ inline std::vector<GPU> GetGPUInfo() {
   // Only support for nvidia for now
   // auto gpus = hwinfo::getAllGPUs();
   auto nvidia_gpus = system_info_utils::GetGpuInfoList();
-  auto cuda_version = system_info_utils::GetCudaVersion();
   for (auto& n : nvidia_gpus) {
     res.emplace_back(
         GPU{.id = n.id,
             .name = n.name,
-            .version = cuda_version,
+            .version = nvidia_gpus[0].cuda_driver_version.value_or("unknown"),
             .add_info =
                 NvidiaAddInfo{
                     .driver_version = n.driver_version.value_or("unknown"),


### PR DESCRIPTION
## Describe Your Changes

- In a machine without `nvidia-driver` but `nvidia-smi` installed, the `nvidia-smi` takes around ~1 second. Workaround to minimize `nvidia-smi` call. 
- TODO: get Nvidia driver version and CUDA version by reading Nvidia dynamic library.

## Fixes Issues

- https://github.com/janhq/jan/issues/4171

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed