### PR TITLE
fix: support ctx_len for model start cli

### DIFF
--- a/docs/docs/cli/models/index.mdx
+++ b/docs/docs/cli/models/index.mdx
@@ -159,9 +159,10 @@ This command uses a `model_id` from the model that you have downloaded or availa
 
 | Option                    | Description                                                               | Required | Default value                                | Example                |
 |---------------------------|---------------------------------------------------------------------------|----------|----------------------------------------------|------------------------|
-| `model_id`                | The identifier of the model you want to start.                            | Yes       | `Prompt to select from the available models` | `mistral`       |
-| `--gpus`                  | List of GPUs to use.                                                      | No       | -                                            | `[0,1]`           |
-| `-h`, `--help`            | Display help information for the command.                                 | No       | -                                            | `-h`               |
+| `model_id`                | The identifier of the model you want to start.                            | Yes      | `Prompt to select from the available models` | `mistral`              |
+| `--gpus`                  | List of GPUs to use.                                                      | No       | -                                            | `[0,1]`                |
+| `--ctx_len`               | Maximum context length for inference.                                     | No       | `min(8192, max_model_context_length)`        | `1024`                 |
+| `-h`, `--help`            | Display help information for the command.                                 | No       | -                                            | `-h`                   |
 
 ## `cortex models stop`
 :::info

--- a/docs/docs/cli/models/start.md
+++ b/docs/docs/cli/models/start.md
@@ -33,6 +33,7 @@ cortex models start [model_id]:[engine] [options]
 |---------------------------|----------------------------------------------------------|----------|----------------------------------------------|-------------------|
 | `model_id`                | The identifier of the model you want to start.           | No       | `Prompt to select from the available models` | `mistral`         |
 | `--gpus`                  | List of GPUs to use.                                     | No       | -                                            | `[0,1]`           |
+| `--ctx_len`               | Maximum context length for inference.                    | No       | `min(8192, max_model_context_length)`        | `1024`            |
 | `-h`, `--help`            | Display help information for the command.                | No       | -                                            | `-h`              |
 
 

--- a/docs/docs/cli/run.mdx
+++ b/docs/docs/cli/run.mdx
@@ -36,7 +36,8 @@ You can use the `--verbose` flag to display more detailed output of the internal
 
 | Option                      | Description                                                                 | Required | Default value                                | Example                |
 |-----------------------------|-----------------------------------------------------------------------------|----------|----------------------------------------------|------------------------|
-| `model_id`                  | The identifier of the model you want to chat with.                          | Yes       | - | `mistral`       |
-| `--gpus`                   | List of GPUs to use.                                                         | No       | -                                            | `[0,1]`           |
+| `model_id`                  | The identifier of the model you want to chat with.                          | Yes      | - | `mistral`       |
+| `--gpus`                    | List of GPUs to use.                                                        | No       | -                                            | `[0,1]`           |
+| `--ctx_len`                 | Maximum context length for inference.                                       | No       | `min(8192, max_model_context_length)`        | `1024`                 |
 | `-h`, `--help`              | Display help information for the command.                                   | No       | -                                            | `-h`               |
 <!-- | `-t`, `--thread <thread_id>`  | Specify the Thread ID. Defaults to creating a new thread if none specified. | No       | -                                            | `-t jan_1717650808`       |                                      | `-c`               | -->

--- a/engine/cli/command_line_parser.h
+++ b/engine/cli/command_line_parser.h
@@ -79,5 +79,5 @@ class CommandLineParser {
   std::unordered_map<std::string, std::string> config_update_opts_;
   bool executed_ = false;
   commands::HarwareOptions hw_opts_;
-  std::unordered_map<std::string, std::string> hw_activate_opts_;
+  std::unordered_map<std::string, std::string> run_settings_;
 };

--- a/engine/cli/commands/model_start_cmd.h
+++ b/engine/cli/commands/model_start_cmd.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include "json/json.h"
 
 namespace commands {
 
@@ -10,5 +11,8 @@ class ModelStartCmd {
   bool Exec(const std::string& host, int port, const std::string& model_handle,
             const std::unordered_map<std::string, std::string>& options,
             bool print_success_log = true);
+    private:
+  bool UpdateConfig(Json::Value& data, const std::string& key,
+                    const std::string& value);
 };
 }  // namespace commands

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -732,6 +732,7 @@ cpp::result<StartModelResult, std::string> ModelService::StartModel(
       json_data["system_prompt"] = mc.system_template;
       json_data["user_prompt"] = mc.user_template;
       json_data["ai_prompt"] = mc.ai_template;
+      json_data["ctx_len"] = std::min(8192, mc.ctx_len);
     } else {
       bypass_stop_check_set_.insert(model_handle);
     }


### PR DESCRIPTION
## Describe Your Changes

Syntax:
```
cortex models start tinyllama:gguf --ctx_len 1024
cortex run tinyllama:gguf --ctx_len 1024
```

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1668

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed