### PR TITLE
fix: correct stop inferencing condition

### DIFF
--- a/engine/controllers/server.cc
+++ b/engine/controllers/server.cc
@@ -140,7 +140,9 @@ void server::ProcessStreamRes(std::function<void(const HttpResponsePtr&)> cb,
                                       std::size_t buf_size) -> std::size_t {
     if (buf == nullptr) {
       LOG_TRACE << "Buf is null";
-      inference_svc_->StopInferencing(engine_type, model_id);
+      if (!(*err_or_done)) {
+        inference_svc_->StopInferencing(engine_type, model_id);
+      }
       return 0;
     }
 


### PR DESCRIPTION
## Describe Your Changes

- Only force stop inferencing if the connection is interrupted

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed