### PR TITLE
fix: add support image url for jan

### DIFF
--- a/engine/common/message_content_text.h
+++ b/engine/common/message_content_text.h
@@ -122,7 +122,6 @@ struct FilePathWrapper : Annotation {
 
 struct Text : JsonSerializable {
   // The data that makes up the text.
-
   Text() = default;
 
   Text(Text&&) noexcept = default;
@@ -213,6 +212,8 @@ struct TextContent : Content {
   TextContent& operator=(const TextContent&) = delete;
 
   Text text;
+
+  ~TextContent() override = default;
 
   static cpp::result<TextContent, std::string> FromJson(Json::Value&& json) {
     if (json.empty()) {

--- a/engine/test/components/test_models_db.cc
+++ b/engine/test/components/test_models_db.cc
@@ -1,6 +1,5 @@
 #include "database/models.h"
 #include "gtest/gtest.h"
-#include "utils/file_manager_utils.h"
 
 namespace cortex::db {
 namespace {


### PR DESCRIPTION
## Describe Your Changes

- Add support for image url jan.
```json
"content": [
                {
                    "text": {
                        "annotations": [],
                        "value": "What is this image about?"
                    },
                    "type": "text"
                },
                {
                    "image_url": {
                        "detail": "auto",
                        "url": "threads/jan_1734081137/files/01JEZMN5DKCX8MJG2W7P6NYCC0.png"
                    },
                    "type": "image_url"
                }
            ],
```

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed