### PR TITLE
fix: only use dll search path if ENGINE_PATH is not set

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -704,21 +704,24 @@ cpp::result<void, std::string> EngineService::LoadEngine(
 
 #if defined(_WIN32) || defined(_WIN64)
     // register deps
-    std::vector<std::filesystem::path> paths{};
-    paths.push_back(std::move(cuda_path));
-    paths.push_back(std::move(engine_dir_path));
+    if (bool should_use_dll_search_path = !(getenv("ENGINE_PATH"));
+        should_use_dll_search_path) {
+      std::vector<std::filesystem::path> paths{};
+      paths.push_back(std::move(cuda_path));
+      paths.push_back(std::move(engine_dir_path));
 
-    CTL_DBG("Registering dylib for "
-            << ne << " with " << std::to_string(paths.size()) << " paths.");
-    for (const auto& path : paths) {
-      CTL_DBG("Registering path: " << path.string());
-    }
+      CTL_DBG("Registering dylib for "
+              << ne << " with " << std::to_string(paths.size()) << " paths.");
+      for (const auto& path : paths) {
+        CTL_DBG("Registering path: " << path.string());
+      }
 
-    auto reg_result = dylib_path_manager_->RegisterPath(ne, paths);
-    if (reg_result.has_error()) {
-      CTL_DBG("Failed register lib paths for: " << ne);
-    } else {
-      CTL_DBG("Registered lib paths for: " << ne);
+      auto reg_result = dylib_path_manager_->RegisterPath(ne, paths);
+      if (reg_result.has_error()) {
+        CTL_DBG("Failed register lib paths for: " << ne);
+      } else {
+        CTL_DBG("Registered lib paths for: " << ne);
+      }
     }
 #endif
 

--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -704,8 +704,7 @@ cpp::result<void, std::string> EngineService::LoadEngine(
 
 #if defined(_WIN32) || defined(_WIN64)
     // register deps
-    if (bool should_use_dll_search_path = !(getenv("ENGINE_PATH"));
-        should_use_dll_search_path) {
+    if (!(getenv("ENGINE_PATH"))) {
       std::vector<std::filesystem::path> paths{};
       paths.push_back(std::move(cuda_path));
       paths.push_back(std::move(engine_dir_path));


### PR DESCRIPTION
## Describe Your Changes

-

## Fixes Issues

- https://github.com/janhq/jan/issues/4291#issuecomment-2550828968

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed