### PR TITLE
fix: using engine variant name for download task id

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -8,7 +8,6 @@
 #include "database/engines.h"
 #include "extensions/remote-engine/remote_engine.h"
 #include "utils/archive_utils.h"
-#include "utils/cpuid/cpu_info.h"
 #include "utils/engine_constants.h"
 #include "utils/engine_matcher_utils.h"
 #include "utils/file_manager_utils.h"
@@ -364,10 +363,10 @@ cpp::result<void, std::string> EngineService::DownloadEngine(
   };
 
   auto downloadTask =
-      DownloadTask{.id = engine,
+      DownloadTask{.id = selected_variant->name,
                    .type = DownloadType::Engine,
                    .items = {DownloadItem{
-                       .id = engine,
+                       .id = selected_variant->name,
                        .downloadUrl = selected_variant->browser_download_url,
                        .localPath = variant_path,
                    }}};


### PR DESCRIPTION
## Describe Your Changes

- Using engine variant name for download task id.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed