### PR TITLE
fix: use after std::move

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -763,8 +763,8 @@ cpp::result<void, std::string> EngineService::LoadEngine(
     // register deps
     if (!(getenv("ENGINE_PATH"))) {
       std::vector<std::filesystem::path> paths{};
-      paths.push_back(std::move(cuda_path));
-      paths.push_back(std::move(engine_dir_path));
+      paths.push_back(cuda_path);
+      paths.push_back(engine_dir_path);
 
       CTL_DBG("Registering dylib for "
               << ne << " with " << std::to_string(paths.size()) << " paths.");
@@ -830,8 +830,8 @@ void EngineService::RegisterEngineLibPath() {
 
       // register deps
       std::vector<std::filesystem::path> paths{};
-      paths.push_back(std::move(cuda_path));
-      paths.push_back(std::move(engine_dir_path));
+      paths.push_back(cuda_path);
+      paths.push_back(engine_dir_path);
 
       CTL_DBG("Registering dylib for "
               << ne << " with " << std::to_string(paths.size()) << " paths.");


### PR DESCRIPTION
This pull request includes changes to the `engine/services/engine_service.cc` file to improve the handling of paths in the `LoadEngine` and `RegisterEngineLibPath` methods. The most important changes involve the removal of buggy `std::move` (use after move) operations when pushing back paths into the `std::vector`.

Codebase simplification:

* [`engine/services/engine_service.cc`](diffhunk://#diff-4c0c7acfd254155d48f2cb45c2e430faec94985cdf5ce46710e0bd615eeb3366L766-R767): Removed unnecessary `std::move` operations when pushing `cuda_path` and `engine_dir_path` into the `paths` vector in both the `LoadEngine` and `RegisterEngineLibPath` methods. [[1]](diffhunk://#diff-4c0c7acfd254155d48f2cb45c2e430faec94985cdf5ce46710e0bd615eeb3366L766-R767) [[2]](diffhunk://#diff-4c0c7acfd254155d48f2cb45c2e430faec94985cdf5ce46710e0bd615eeb3366L833-R834)## Describe Your Changes
