### PR TITLE
fix: add cpu_threads to model.yaml

### DIFF
--- a/engine/cli/command_line_parser.cc
+++ b/engine/cli/command_line_parser.cc
@@ -908,6 +908,7 @@ void CommandLineParser::ModelUpdate(CLI::App* parent) {
                                            "ngl",
                                            "ctx_len",
                                            "n_parallel",
+                                           "cpu_threads",
                                            "engine",
                                            "prompt_template",
                                            "system_template",

--- a/engine/cli/commands/model_upd_cmd.cc
+++ b/engine/cli/commands/model_upd_cmd.cc
@@ -228,6 +228,12 @@ void ModelUpdCmd::UpdateConfig(Json::Value& data, const std::string& key,
                data["n_parallel"] = static_cast<int>(f);
              });
            }},
+           {"cpu_threads",
+           [this](Json::Value &data, const std::string& k, const std::string& v) {
+             UpdateNumericField(k, v, [&data](float f) {
+               data["cpu_threads"] = static_cast<int>(f);
+             });
+           }},
           {"tp",
            [this](Json::Value &data, const std::string& k, const std::string& v) {
              UpdateNumericField(k, v, [&data](float f) {

--- a/engine/config/model_config.h
+++ b/engine/config/model_config.h
@@ -164,6 +164,7 @@ struct ModelConfig {
   int ngl = std::numeric_limits<int>::quiet_NaN();
   int ctx_len = std::numeric_limits<int>::quiet_NaN();
   int n_parallel = 1;
+  int cpu_threads = -1;
   std::string engine;
   std::string prompt_template;
   std::string system_template;
@@ -272,6 +273,8 @@ struct ModelConfig {
       ctx_len = json["ctx_len"].asInt();
     if (json.isMember("n_parallel"))
       n_parallel = json["n_parallel"].asInt();
+    if (json.isMember("cpu_threads"))
+      cpu_threads = json["cpu_threads"].asInt();
     if (json.isMember("engine"))
       engine = json["engine"].asString();
     if (json.isMember("prompt_template"))
@@ -362,6 +365,9 @@ struct ModelConfig {
     obj["ngl"] = ngl;
     obj["ctx_len"] = ctx_len;
     obj["n_parallel"] = n_parallel;
+    if (cpu_threads > 0) {
+      obj["cpu_threads"] = cpu_threads;
+    }
     obj["engine"] = engine;
     obj["prompt_template"] = prompt_template;
     obj["system_template"] = system_template;
@@ -473,6 +479,8 @@ struct ModelConfig {
       oss << format_utils::print_kv("ctx_len", std::to_string(ctx_len),
                                     format_utils::MAGENTA);
     oss << format_utils::print_kv("n_parallel", std::to_string(n_parallel),
+                                  format_utils::MAGENTA);
+    oss << format_utils::print_kv("cpu_threads", std::to_string(cpu_threads),
                                   format_utils::MAGENTA);
     if (ngl != std::numeric_limits<int>::quiet_NaN())
       oss << format_utils::print_kv("ngl", std::to_string(ngl),

--- a/engine/test/components/test_format_utils.cc
+++ b/engine/test/components/test_format_utils.cc
@@ -9,37 +9,37 @@ TEST_F(FormatUtilsTest, WriteKeyValue) {
   {
     YAML::Node node;
     std::string result =
-        format_utils::writeKeyValue("key", node["does_not_exist"]);
+        format_utils::WriteKeyValue("key", node["does_not_exist"]);
     EXPECT_EQ(result, "");
   }
 
   {
     YAML::Node node = YAML::Load("value");
-    std::string result = format_utils::writeKeyValue("key", node);
+    std::string result = format_utils::WriteKeyValue("key", node);
     EXPECT_EQ(result, "key: value\n");
   }
 
   {
     YAML::Node node = YAML::Load("3.14159");
-    std::string result = format_utils::writeKeyValue("key", node);
+    std::string result = format_utils::WriteKeyValue("key", node);
     EXPECT_EQ(result, "key: 3.14159\n");
   }
 
   {
     YAML::Node node = YAML::Load("3.000000");
-    std::string result = format_utils::writeKeyValue("key", node);
+    std::string result = format_utils::WriteKeyValue("key", node);
     EXPECT_EQ(result, "key: 3\n");
   }
 
   {
     YAML::Node node = YAML::Load("3.140000");
-    std::string result = format_utils::writeKeyValue("key", node);
+    std::string result = format_utils::WriteKeyValue("key", node);
     EXPECT_EQ(result, "key: 3.14\n");
   }
 
   {
     YAML::Node node = YAML::Load("value");
-    std::string result = format_utils::writeKeyValue("key", node, "comment");
+    std::string result = format_utils::WriteKeyValue("key", node, "comment");
     EXPECT_EQ(result, "key: value # comment\n");
   }
 }

--- a/engine/test/components/test_yaml_handler.cc
+++ b/engine/test/components/test_yaml_handler.cc
@@ -63,6 +63,7 @@ temperature: 0.7
 max_tokens: 100
 stream: true
 n_parallel: 2
+cpu_threads: 3
 stop:
   - "END"
 files:
@@ -84,6 +85,7 @@ files:
   EXPECT_EQ(config.max_tokens, 100);
   EXPECT_TRUE(config.stream);
   EXPECT_EQ(config.n_parallel, 2);
+  EXPECT_EQ(config.cpu_threads, 3);
   EXPECT_EQ(config.stop.size(), 1);
   EXPECT_EQ(config.stop[0], "END");
   EXPECT_EQ(config.files.size(), 1);
@@ -104,6 +106,7 @@ TEST_F(YamlHandlerTest, UpdateModelConfig) {
   new_config.max_tokens = 200;
   new_config.stream = false;
   new_config.n_parallel = 2;
+  new_config.cpu_threads = 3;
   new_config.stop = {"STOP", "END"};
   new_config.files = {"updated_file1.gguf", "updated_file2.gguf"};
 
@@ -120,6 +123,7 @@ TEST_F(YamlHandlerTest, UpdateModelConfig) {
   EXPECT_EQ(config.max_tokens, 200);
   EXPECT_FALSE(config.stream);
   EXPECT_EQ(config.n_parallel, 2);
+  EXPECT_EQ(config.cpu_threads, 3);
   EXPECT_EQ(config.stop.size(), 2);
   EXPECT_EQ(config.stop[0], "STOP");
   EXPECT_EQ(config.stop[1], "END");
@@ -140,6 +144,7 @@ TEST_F(YamlHandlerTest, WriteYamlFile) {
   new_config.max_tokens = 150;
   new_config.stream = true;
   new_config.n_parallel = 2;
+  new_config.cpu_threads = 3;
   new_config.stop = {"HALT"};
   new_config.files = {"write_test_file.gguf"};
 
@@ -164,6 +169,7 @@ TEST_F(YamlHandlerTest, WriteYamlFile) {
   EXPECT_EQ(read_config.max_tokens, 150);
   EXPECT_TRUE(read_config.stream);
   EXPECT_EQ(read_config.n_parallel, 2);
+  EXPECT_EQ(read_config.cpu_threads, 3);
   EXPECT_EQ(read_config.stop.size(), 1);
   EXPECT_EQ(read_config.stop[0], "HALT");
   EXPECT_EQ(read_config.files.size(), 1);

--- a/engine/utils/format_utils.h
+++ b/engine/utils/format_utils.h
@@ -46,13 +46,13 @@ inline std::string print_float(const std::string& key, float value) {
   } else
     return "";
 };
-inline std::string writeKeyValue(const std::string& key,
+inline std::string WriteKeyValue(const std::string& key,
                                  const YAML::Node& value,
                                  const std::string& comment = "") {
-  std::ostringstream outFile;
+  std::ostringstream out_file;
   if (!value)
     return "";
-  outFile << key << ": ";
+  out_file << key << ": ";
 
   // Check if the value is a float and round it to 6 decimal places
   if (value.IsScalar()) {
@@ -66,19 +66,19 @@ inline std::string writeKeyValue(const std::string& key,
       if (strValue.back() == '.') {
         strValue.pop_back();
       }
-      outFile << strValue;
+      out_file << strValue;
     } catch (const std::exception& e) {
-      outFile << value;  // If not a float, write as is
+      out_file << value;  // If not a float, write as is
     }
   } else {
-    outFile << value;
+    out_file << value;
   }
 
   if (!comment.empty()) {
-    outFile << " # " << comment;
+    out_file << " # " << comment;
   }
-  outFile << "\n";
-  return outFile.str();
+  out_file << "\n";
+  return out_file.str();
 };
 
 inline std::string BytesToHumanReadable(uint64_t bytes) {


### PR DESCRIPTION
This pull request introduces a new configuration parameter, `cpu_threads`, to various parts of the codebase, and refactors the `writeKeyValue` method to `WriteKeyValue` for consistency. The most important changes include updates to the `ModelConfig` structure, YAML handling, and test cases.

### New Configuration Parameter `cpu_threads`:

* [`engine/cli/command_line_parser.cc`](diffhunk://#diff-71fe23d497d6ae3e75be8d81c75f1da9115a5e2ea7d8ec091f1cf5a3d5c8fc5cR911): Added `cpu_threads` to the list of command line options.
* [`engine/cli/commands/model_upd_cmd.cc`](diffhunk://#diff-bdd41dc2fd04419d8343357866d1eab68f018c7f56089126b19f57eefba3c4deR231-R236): Added handling for the `cpu_threads` parameter in the `UpdateConfig` method.
* [`engine/config/model_config.h`](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR167): Updated `ModelConfig` structure to include `cpu_threads` with appropriate serialization and deserialization logic. [[1]](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR167) [[2]](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR276-R277) [[3]](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR368-R370) [[4]](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR483-R484)
* [`engine/config/yaml_config.cc`](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R122-R123): Updated YAML handling to include `cpu_threads` in `ModelConfigFromYaml` and `UpdateModelConfig` methods. [[1]](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R122-R123) [[2]](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R229-R230) [[3]](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7L286-R395)

### Refactoring `writeKeyValue` to `WriteKeyValue`:

* [`engine/utils/format_utils.h`](diffhunk://#diff-888f4f6a2619ae8891da6c81c054db3ab2b92e5745ce87adad6a92631ce4b34aL49-R55): Renamed `writeKeyValue` to `WriteKeyValue` and updated variable names for consistency. [[1]](diffhunk://#diff-888f4f6a2619ae8891da6c81c054db3ab2b92e5745ce87adad6a92631ce4b34aL49-R55) [[2]](diffhunk://#diff-888f4f6a2619ae8891da6c81c054db3ab2b92e5745ce87adad6a92631ce4b34aL69-R81)
* [`engine/config/yaml_config.cc`](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7L286-R395): Updated all instances of `writeKeyValue` to `WriteKeyValue`.
* [`engine/test/components/test_format_utils.cc`](diffhunk://#diff-829dd7b2776b5033f9657f0e6022169089487e1bb67a3c49b9b9536673759d5aL12-R42): Updated test cases to use `WriteKeyValue`.

### Test Case Updates:

* [`engine/test/components/test_yaml_handler.cc`](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR66): Added test cases for `cpu_threads` in YAML handling and updated existing tests to include `cpu_threads`. [[1]](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR66) [[2]](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR88) [[3]](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR109) [[4]](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR126) [[5]](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR147) [[6]](diffhunk://#diff-25c34f8d4729da1b65414d6a0815e3e8109719262b0ca0248602cb9bf6fb209bR172)## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed