### PR TITLE
fix: remove url check for remote engine

### DIFF
--- a/engine/controllers/engines.cc
+++ b/engine/controllers/engines.cc
@@ -251,9 +251,9 @@ void Engines::InstallRemoteEngine(
                               .get("get_models_url", "")
                               .asString();
 
-    if (engine.empty() || type.empty() || url.empty()) {
+    if (engine.empty() || type.empty()) {
       Json::Value res;
-      res["message"] = "Engine name, type, url are required";
+      res["message"] = "Engine name, type are required";
       auto resp = cortex_utils::CreateCortexHttpJsonResponse(res);
       resp->setStatusCode(k400BadRequest);
       callback(resp);


### PR DESCRIPTION
This pull request includes a small change to the `void Engines::InstallRemoteEngine` method in the `engine/controllers/engines.cc` file. The change modifies the condition to check for the presence of the `url` parameter and updates the corresponding error message.

* [`engine/controllers/engines.cc`](diffhunk://#diff-9670c5f1e31a31aa3efb3ae8a3ecc54edd88aa7a4b2bf129de607612f826fc3bL254-R256): Removed the check for the `url` parameter and updated the error message to reflect that only the engine name and type are required.## Describe Your Changes
