### PR TITLE
fix: check model status before inferencing

### DIFF
--- a/engine/services/inference_service.cc
+++ b/engine/services/inference_service.cc
@@ -14,6 +14,21 @@ cpp::result<void, InferResult> InferenceService::HandleChatCompletion(
   }
   function_calling_utils::PreprocessRequest(json_body);
   auto tool_choice = json_body->get("tool_choice", Json::Value::null);
+  auto model_id = json_body->get("model", "").asString();
+  if (saved_models_.find(model_id) != saved_models_.end()) {
+    // check if model is started, if not start it first
+    Json::Value root;
+    root["model"] = model_id;
+    root["engine"] = engine_type;
+    auto ir = GetModelStatus(std::make_shared<Json::Value>(root));
+    auto status = std::get<0>(ir)["status_code"].asInt();
+    if (status != drogon::k200OK) {
+      CTL_INF("Model is not loaded, start loading it: " << model_id);
+      auto res = LoadModel(saved_models_.at(model_id));
+      // ignore return result
+    }
+  }
+
   auto engine_result = engine_service_->GetLoadedEngine(engine_type);
   if (engine_result.has_error()) {
     Json::Value res;
@@ -23,45 +38,42 @@ cpp::result<void, InferResult> InferenceService::HandleChatCompletion(
     LOG_WARN << "Engine is not loaded yet";
     return cpp::fail(std::make_pair(stt, res));
   }
+ 
+  if (!model_id.empty()) {
+    if (auto model_service = model_service_.lock()) {
+      auto metadata_ptr = model_service->GetCachedModelMetadata(model_id);
+      if (metadata_ptr != nullptr &&
+          !metadata_ptr->tokenizer->chat_template.empty()) {
+        auto tokenizer = metadata_ptr->tokenizer;
+        auto messages = (*json_body)["messages"];
+        Json::Value messages_jsoncpp(Json::arrayValue);
+        for (auto message : messages) {
+          messages_jsoncpp.append(message);
+        }
 
-  {
-    auto model_id = json_body->get("model", "").asString();
-    if (!model_id.empty()) {
-      if (auto model_service = model_service_.lock()) {
-        auto metadata_ptr = model_service->GetCachedModelMetadata(model_id);
-        if (metadata_ptr != nullptr &&
-            !metadata_ptr->tokenizer->chat_template.empty()) {
-          auto tokenizer = metadata_ptr->tokenizer;
-          auto messages = (*json_body)["messages"];
-          Json::Value messages_jsoncpp(Json::arrayValue);
-          for (auto message : messages) {
-            messages_jsoncpp.append(message);
-          }
+        Json::Value tools(Json::arrayValue);
+        Json::Value template_data_json;
+        template_data_json["messages"] = messages_jsoncpp;
+        // template_data_json["tools"] = tools;
 
-          Json::Value tools(Json::arrayValue);
-          Json::Value template_data_json;
-          template_data_json["messages"] = messages_jsoncpp;
-          // template_data_json["tools"] = tools;
-
-          auto prompt_result = jinja::RenderTemplate(
-              tokenizer->chat_template, template_data_json,
-              tokenizer->bos_token, tokenizer->eos_token,
-              tokenizer->add_bos_token, tokenizer->add_eos_token,
-              tokenizer->add_generation_prompt);
-          if (prompt_result.has_value()) {
-            (*json_body)["prompt"] = prompt_result.value();
-            Json::Value stops(Json::arrayValue);
-            stops.append(tokenizer->eos_token);
-            (*json_body)["stop"] = stops;
-          } else {
-            CTL_ERR("Failed to render prompt: " + prompt_result.error());
-          }
+        auto prompt_result = jinja::RenderTemplate(
+            tokenizer->chat_template, template_data_json, tokenizer->bos_token,
+            tokenizer->eos_token, tokenizer->add_bos_token,
+            tokenizer->add_eos_token, tokenizer->add_generation_prompt);
+        if (prompt_result.has_value()) {
+          (*json_body)["prompt"] = prompt_result.value();
+          Json::Value stops(Json::arrayValue);
+          stops.append(tokenizer->eos_token);
+          (*json_body)["stop"] = stops;
+        } else {
+          CTL_ERR("Failed to render prompt: " + prompt_result.error());
         }
       }
     }
   }
 
-  CTL_INF("Json body inference: " + json_body->toStyledString());
+
+  CTL_DBG("Json body inference: " + json_body->toStyledString());
 
   auto cb = [q, tool_choice](Json::Value status, Json::Value res) {
     if (!tool_choice.isNull()) {
@@ -204,6 +216,10 @@ InferResult InferenceService::LoadModel(
   } else {
     std::get<RemoteEngineI*>(engine_result.value())
         ->LoadModel(json_body, std::move(cb));
+  }
+  if (!engine_service_->IsRemoteEngine(engine_type)) {
+    auto model_id = json_body->get("model", "").asString();
+    saved_models_[model_id] = json_body;
   }
   return std::make_pair(stt, r);
 }

--- a/engine/services/inference_service.h
+++ b/engine/services/inference_service.h
@@ -47,7 +47,7 @@ class InferenceService {
 
   cpp::result<void, InferResult> HandleRouteRequest(
       std::shared_ptr<SyncQueue> q, std::shared_ptr<Json::Value> json_body);
-      
+
   InferResult LoadModel(std::shared_ptr<Json::Value> json_body);
 
   InferResult UnloadModel(const std::string& engine,
@@ -74,4 +74,6 @@ class InferenceService {
  private:
   std::shared_ptr<EngineService> engine_service_;
   std::weak_ptr<ModelService> model_service_;
+  using SavedModel = std::shared_ptr<Json::Value>;
+  std::unordered_map<std::string, SavedModel> saved_models_;
 };


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces several changes to the `InferenceService` class and related methods to improve model handling and logging. The most important changes include adding logic to handle model loading, updating logging levels, and modifying the storage of saved models.

Improvements to model handling and storage:

* [`engine/services/inference_service.cc`](diffhunk://#diff-e165ef8bee4fa9dfd1a2d044abdc345eb7784ee2708a14cd582cb33ec9beceb0R17-R31): Added logic to check if a model is loaded and start loading it if not. This includes retrieving the model status and initiating the model loading process if necessary.
* [`engine/services/inference_service.cc`](diffhunk://#diff-e165ef8bee4fa9dfd1a2d044abdc345eb7784ee2708a14cd582cb33ec9beceb0L27-L28): Removed redundant code for retrieving the `model_id` inside a nested block and consolidated it at the beginning of the function.
* [`engine/services/inference_service.cc`](diffhunk://#diff-e165ef8bee4fa9dfd1a2d044abdc345eb7784ee2708a14cd582cb33ec9beceb0R220-R223): Added logic to save models in the `saved_models_` map when they are loaded, ensuring they can be reused later.
* [`engine/services/inference_service.h`](diffhunk://#diff-982ee4a7c116ccf3459c96341d29ccaabe691a2347d857286d92b9ea6bc531d0R77-R78): Introduced a new `SavedModel` type and an `unordered_map` to store saved models, facilitating efficient model retrieval.

Logging improvements:

* [`engine/services/inference_service.cc`](diffhunk://#diff-e165ef8bee4fa9dfd1a2d044abdc345eb7784ee2708a14cd582cb33ec9beceb0L62-R76): Changed the logging level from `CTL_INF` to `CTL_DBG` for the JSON body inference message to reduce log verbosity.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1863

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed