### PR TITLE
chore: cherry pick log bugfix

### DIFF
--- a/engine/utils/file_logger.cc
+++ b/engine/utils/file_logger.cc
@@ -117,9 +117,9 @@ void FileLogger::CircularLogFile::TruncateFileIfNeeded() {
 void FileLogger::CircularLogFile::OpenFile() {
 #ifdef _WIN32
   auto wFileName = utils::toNativePath(file_name_);
-  fp_ = _wfopen(wFileName.c_str(), L"r+");
+  fp_ = _wfopen(wFileName.c_str(), L"a+");
 #else
-  fp_ = fopen(file_name_.c_str(), "r+");
+  fp_ = fopen(file_name_.c_str(), "a+");
 #endif
 
   if (!fp_) {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `engine/utils/file_logger.cc` file to modify the file opening mode in the `FileLogger::CircularLogFile::OpenFile` method.

File opening mode change:

* [`engine/utils/file_logger.cc`](diffhunk://#diff-bfb089d2a2661e0c5a17b57502bff20c712f9ee48928fd7a17c1da3c24544966L120-R122): Changed the file opening mode from `"r+"` to `"a+"` in the `FileLogger::CircularLogFile::OpenFile` method to ensure that the file is opened for appending and reading, rather than reading and writing. This change affects both Windows and non-Windows platforms.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed