### PR TITLE
fix: ignore compute_cap if not present

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -404,17 +404,6 @@ cpp::result<bool, std::string> EngineService::DownloadCuda(
   auto suitable_toolkit_version =
       GetSuitableCudaVersion(engine, hw_inf_.cuda_driver_version);
 
-  // compare cuda driver version with cuda toolkit version
-  // cuda driver version should be greater than toolkit version to ensure compatibility
-  if (semantic_version_utils::CompareSemanticVersion(
-          hw_inf_.cuda_driver_version, suitable_toolkit_version) < 0) {
-    CTL_ERR("Your Cuda driver version "
-            << hw_inf_.cuda_driver_version
-            << " is not compatible with cuda toolkit version "
-            << suitable_toolkit_version);
-    return cpp::fail("Cuda driver is not compatible with cuda toolkit");
-  }
-
   auto url_obj = url_parser::Url{
       .protocol = "https",
       .host = jan_host,

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -17,7 +17,7 @@ inline std::vector<GPU> GetGPUInfo() {
 
   for (size_t i = 0; i < nvidia_gpus.size(); i++) {
     for (size_t j = 0; j < vulkan_gpus.size(); j++) {
-      if (nvidia_gpus[i].uuid == vulkan_gpus[j].uuid) {
+      if (nvidia_gpus[i].uuid.find(vulkan_gpus[j].uuid) != std::string::npos) {
         vulkan_gpus[j].version =
             nvidia_gpus[0].cuda_driver_version.value_or("unknown");
         vulkan_gpus[j].add_info = NvidiaAddInfo{

--- a/engine/utils/system_info_utils.cc
+++ b/engine/utils/system_info_utils.cc
@@ -108,26 +108,32 @@ std::vector<GpuInfo> GetGpuInfoList() {
     auto [driver_version, cuda_version] = GetDriverAndCudaVersion();
     if (driver_version.empty() || cuda_version.empty())
       return gpuInfoList;
-
+    bool need_fallback = false;
     CommandExecutor cmd(kGpuQueryCommand);
     auto output = cmd.execute();
+    if (output.find("NVIDIA") == std::string::npos) {
+      need_fallback = true;
+      output = CommandExecutor(kGpuQueryCommandFb).execute();
+    }
 
-    const std::regex gpu_info_reg(kGpuInfoRegex);
+    std::string rg = need_fallback ? kGpuInfoRegexFb : kGpuInfoRegex;
+    const std::regex gpu_info_reg(rg);
     std::smatch match;
     std::string::const_iterator search_start(output.cbegin());
+    int rg_count = need_fallback ? 5 : 6;
 
     while (
         std::regex_search(search_start, output.cend(), match, gpu_info_reg)) {
       GpuInfo gpuInfo = {
-          match[1].str(),              // id
-          match[2].str(),              // vram_total
-          match[3].str(),              // vram_free
-          match[4].str(),              // name
-          GetGpuArch(match[4].str()),  // arch
-          driver_version,              // driver_version
-          cuda_version,                // cuda_driver_version
-          match[5].str(),              // compute_cap
-          match[6].str()               // uuid
+          match[1].str(),                        // id
+          match[2].str(),                        // vram_total
+          match[3].str(),                        // vram_free
+          match[4].str(),                        // name
+          GetGpuArch(match[4].str()),            // arch
+          driver_version,                        // driver_version
+          cuda_version,                          // cuda_driver_version
+          need_fallback ? "0" : match[5].str(),  // compute_cap
+          match[rg_count].str()                  // uuid
       };
       gpuInfoList.push_back(gpuInfo);
       search_start = match.suffix().first;

--- a/engine/utils/system_info_utils.h
+++ b/engine/utils/system_info_utils.h
@@ -25,6 +25,13 @@ constexpr static auto kGpuQueryCommand{
 constexpr static auto kGpuInfoRegex{
     R"((\d+),\s*(\d+),\s*(\d+),\s*([^,]+),\s*([\d\.]+),\s*([^\n,]+))"};
 
+constexpr static auto kGpuQueryCommandFb{
+    "nvidia-smi "
+    "--query-gpu=index,memory.total,memory.free,name,uuid "
+    "--format=csv,noheader,nounits"};
+constexpr static auto kGpuInfoRegexFb{
+    R"((\d+),\s*(\d+),\s*(\d+),\s*([^,]+),\s*([^\n,]+))"};
+
 struct SystemInfo {
   explicit SystemInfo(std::string os, std::string arch)
       : os(std::move(os)), arch(std::move(arch)) {}


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to improve GPU information retrieval and handling in the system utilities. The most important changes include modifying the GPU UUID matching logic, adding a fallback mechanism for GPU queries, and updating regex patterns accordingly.

Improvements to GPU information retrieval:

* [`engine/utils/hardware/gpu_info.h`](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413L20-R20): Changed the GPU UUID matching logic to use `std::string::find` instead of direct comparison.

Fallback mechanism for GPU queries:

* [`engine/utils/system_info_utils.cc`](diffhunk://#diff-06aa0f44eefbc9f6b2429c42ae87cb2c5f63b45d1469505fdf7b806183a651ddL111-R123): Added a fallback mechanism to handle cases where the primary GPU query command does not return NVIDIA GPUs. This includes setting a `need_fallback` flag and executing a fallback command if necessary.
* [`engine/utils/system_info_utils.cc`](diffhunk://#diff-06aa0f44eefbc9f6b2429c42ae87cb2c5f63b45d1469505fdf7b806183a651ddL129-R136): Updated the regex pattern selection and the way GPU information is extracted based on whether the fallback mechanism is used.

Updates to regex patterns and commands:

* [`engine/utils/system_info_utils.h`](diffhunk://#diff-1bfbbdf54b4a5b941d6c9feeada92a79eb5723a2f1fb0efb4db1c6152fb60e0eR28-R34): Added new constants `kGpuQueryCommandFb` and `kGpuInfoRegexFb` for the fallback GPU query command and its corresponding regex pattern.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed