### PR TITLE
fix: remove check for toolkit version

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -404,17 +404,6 @@ cpp::result<bool, std::string> EngineService::DownloadCuda(
   auto suitable_toolkit_version =
       GetSuitableCudaVersion(engine, hw_inf_.cuda_driver_version);
 
-  // compare cuda driver version with cuda toolkit version
-  // cuda driver version should be greater than toolkit version to ensure compatibility
-  if (semantic_version_utils::CompareSemanticVersion(
-          hw_inf_.cuda_driver_version, suitable_toolkit_version) < 0) {
-    CTL_ERR("Your Cuda driver version "
-            << hw_inf_.cuda_driver_version
-            << " is not compatible with cuda toolkit version "
-            << suitable_toolkit_version);
-    return cpp::fail("Cuda driver is not compatible with cuda toolkit");
-  }
-
   auto url_obj = url_parser::Url{
       .protocol = "https",
       .host = jan_host,


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a significant change to the `EngineService::DownloadCuda` method in the `engine_service.cc` file, specifically removing the compatibility check between the CUDA driver version and the CUDA toolkit version.

Codebase simplification:

* [`engine/services/engine_service.cc`](diffhunk://#diff-4c0c7acfd254155d48f2cb45c2e430faec94985cdf5ce46710e0bd615eeb3366L407-L417): Removed the code that compares the CUDA driver version with the CUDA toolkit version to ensure compatibility, including the error handling for incompatible versions.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed