### PR TITLE
fix: permission issue for default drogon uploads folder

### DIFF
--- a/engine/main.cc
+++ b/engine/main.cc
@@ -201,6 +201,9 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
   drogon::app().registerController(hw_ctl);
   drogon::app().registerController(config_ctl);
 
+  auto upload_path = std::filesystem::temp_directory_path() / "cortex-uploads";
+  drogon::app().setUploadPath(upload_path.string());
+
   LOG_INFO << "Server started, listening at: " << config.apiServerHost << ":"
            << config.apiServerPort;
   LOG_INFO << "Please load your model";


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `engine/main.cc` file to enhance the server's file upload functionality. The most important change is the addition of a new upload path for file uploads.

Enhancements to server functionality:

* [`engine/main.cc`](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R204-R206): Added code to set the upload path to the system's temporary directory for file uploads.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed