### PR TITLE
fix: remote engine: handle mistral error on stream mode

### DIFF
--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -526,6 +526,7 @@ void Models::StartModel(
   if (auto& o = (*(req->getJsonObject()))["llama_model_path"]; !o.isNull()) {
     auto model_path = o.asString();
     if (auto& mp = (*(req->getJsonObject()))["model_path"]; mp.isNull()) {
+      mp = model_path;
       // Bypass if model does not exist in DB and llama_model_path exists
       if (std::filesystem::exists(model_path) &&
           !model_service_->HasModel(model_handle)) {

--- a/engine/extensions/remote-engine/remote_engine.cc
+++ b/engine/extensions/remote-engine/remote_engine.cc
@@ -27,8 +27,9 @@ size_t StreamWriteCallback(char* ptr, size_t size, size_t nmemb,
   auto* context = static_cast<StreamContext*>(userdata);
   std::string chunk(ptr, size * nmemb);
   CTL_DBG(chunk);
-  auto check_error = json_helper::ParseJsonString(chunk);
-  if (check_error.isMember("error")) {
+  Json::Value check_error;
+  Json::Reader reader;
+  if (reader.parse(chunk, check_error)) {
     CTL_WRN(chunk);
     Json::Value status;
     status["is_done"] = true;


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to the `engine` module, focusing on improving error handling, bypassing model checks, and ensuring proper model path assignment. The most important changes include updates to the `StartModel` function in `models.cc`, the `StreamWriteCallback` function in `remote_engine.cc`, and the `StartModel` method in `model_service.cc`.

Error handling improvements:

* [`engine/extensions/remote-engine/remote_engine.cc`](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L30-R32): Updated the `StreamWriteCallback` function to use `Json::Reader` for parsing JSON strings, improving error handling for JSON parsing.

Model path assignment:

* [`engine/controllers/models.cc`](diffhunk://#diff-3318b780616ed76cc8983db3e058691572ab10b81522947962d5e107cc171fc8R529): Modified the `StartModel` function to assign the `llama_model_path` to `model_path` if `model_path` is null, ensuring the correct model path is used.

Model check bypass:

* [`engine/services/model_service.cc`](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefR822-R823): Added a condition to bypass the model check for vision models, allowing the `StartModel` method to proceed without checking for model existence in the database.

Code formatting:

* [`engine/services/model_service.cc`](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefL886-L891): Adjusted the formatting of the error message returned when a model fails to start, ensuring better readability.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed