### PR TITLE
chore: correct stop command description

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -131,7 +131,7 @@ This command stops the running model.
 </Tabs>
 
 ## Stop Cortex.cpp API Server
-This command starts the Cortex.cpp API server at `localhost:39281`.
+This command stops the Cortex.cpp API server at `localhost:39281`.
 <Tabs>
   <TabItem value="MacOs/Linux" label="MacOs/Linux">
   ```sh


### PR DESCRIPTION
## Describe Your Changes
This pull request includes a correction to the documentation in the `docs/docs/quickstart.mdx` file. The change corrects the description of a command to accurately reflect that it stops the Cortex.cpp API server instead of starting it.

Documentation correction:

* [`docs/docs/quickstart.mdx`](diffhunk://#diff-f460a0f83b1402fc10a2ab0653f40aba549a2bbed08a971577db8b1a2b5248fcL134-R134): Corrected the description of the command to indicate that it stops the Cortex.cpp API server at `localhost:39281`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed