### PR TITLE
fix: models.cc: symlinked model deletion shouldn't remove original file

### DIFF
--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -461,6 +461,9 @@ void Models::ImportModel(
       model_config.files.push_back(modelPath);
       auto size = std::filesystem::file_size(modelPath);
       model_config.size = size;
+
+      // set this so that it doesn't nuke the original file on model deletion
+      model_entry.branch_name = "imported";
     }
     model_config.model = modelHandle;
     model_config.name = modelName.empty() ? model_config.name : modelName;


### PR DESCRIPTION
## Describe Your Changes

Set the branch name property for symlinked models to `imported`

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1921
- This is because models created in symlink mode are not properly marked as "imported" in the database, so the deletion at https://github.com/janhq/cortex.cpp/blob/596eb947065969045e94f6b76a15b0cb0027ffa5/engine/services/model_service.cc#L768-L773 will nuke the original file.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed