### PR TITLE
fix: set permission for llama-server

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -325,6 +325,22 @@ cpp::result<void, std::string> EngineService::DownloadEngine(
     archive_utils::ExtractArchive(finishedTask.items[0].localPath.string(),
                                   extract_path.string(), true);
 
+#if defined(__linux__) || defined(__APPLE__)
+    // Set permission in case of llama-cpp
+    if (auto ls_path = extract_path / "llama-server";
+        std::filesystem::exists(ls_path)) {
+      try {
+        std::filesystem::permissions(ls_path,
+                                     std::filesystem::perms::owner_exec |
+                                         std::filesystem::perms::group_exec |
+                                         std::filesystem::perms::others_exec,
+                                     std::filesystem::perm_options::add);
+      } catch (const std::filesystem::filesystem_error& e) {
+        CTL_WRN("Error: " << e.what());
+      }
+    }
+#endif
+
     auto variant = engine_matcher_utils::GetVariantFromNameAndVersion(
         selected_variant->name, engine, normalize_version);
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `EngineService::DownloadEngine` method in the `engine_service.cc` file to handle file permissions for extracted archives on Linux and macOS systems.

Permissions handling for extracted archives:

* [`engine/services/engine_service.cc`](diffhunk://#diff-4c0c7acfd254155d48f2cb45c2e430faec94985cdf5ce46710e0bd615eeb3366R328-R343): Added code to set executable permissions on the `llama-server` file if it exists after extraction, specifically for Linux and macOS systems. This ensures that the file has the appropriate permissions for execution.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed