### PR TITLE
fix: correct gpu info list

### DIFF
--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -300,9 +300,9 @@ inline cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
 
   uint32_t extension_count = 0;
   vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
-  std::vector<VkExtensionProperties> availableExtensions(extension_count);
+  std::vector<VkExtensionProperties> available_extensions(extension_count);
   vkEnumerateInstanceExtensionProperties(nullptr, &extension_count,
-                                         availableExtensions.data());
+                                         available_extensions.data());
 
   // Create a Vulkan instance
   VkInstanceCreateInfo instance_create_info = {};
@@ -310,12 +310,12 @@ inline cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
   // If the extension is available, enable it
   std::vector<const char*> enabled_extensions;
 
-  for (const auto& extension : availableExtensions) {
+  for (const auto& extension : available_extensions) {
     enabled_extensions.push_back(extension.extensionName);
   }
 
   instance_create_info.enabledExtensionCount =
-      static_cast<uint32_t>(availableExtensions.size());
+      static_cast<uint32_t>(available_extensions.size());
   instance_create_info.ppEnabledExtensionNames = enabled_extensions.data();
 
   VkInstance instance;

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -8,16 +8,15 @@
 namespace cortex::hw {
 
 inline std::vector<GPU> GetGPUInfo() {
-  std::vector<GPU> res;
-  // Only support for nvidia for now
-  // auto gpus = hwinfo::getAllGPUs();
   auto nvidia_gpus = system_info_utils::GetGpuInfoList();
   auto vulkan_gpus = GetGpuInfoList().value_or(std::vector<cortex::hw::GPU>{});
-  // add more information for GPUs
+  auto use_vulkan_info = nvidia_gpus.empty();
 
+  // In case we have vulkan info, add more information for GPUs
   for (size_t i = 0; i < nvidia_gpus.size(); i++) {
     for (size_t j = 0; j < vulkan_gpus.size(); j++) {
       if (nvidia_gpus[i].uuid.find(vulkan_gpus[j].uuid) != std::string::npos) {
+        use_vulkan_info = true;
         vulkan_gpus[j].version =
             nvidia_gpus[0].cuda_driver_version.value_or("unknown");
         vulkan_gpus[j].add_info = NvidiaAddInfo{
@@ -28,6 +27,25 @@ inline std::vector<GPU> GetGPUInfo() {
       }
     }
   }
-  return vulkan_gpus;
+  
+  if (use_vulkan_info) {
+    return vulkan_gpus;
+  } else {
+    std::vector<GPU> res;
+    for (auto& n : nvidia_gpus) {
+      res.emplace_back(
+          GPU{.id = n.id,
+              .name = n.name,
+              .version = nvidia_gpus[0].cuda_driver_version.value_or("unknown"),
+              .add_info =
+                  NvidiaAddInfo{
+                      .driver_version = n.driver_version.value_or("unknown"),
+                      .compute_cap = n.compute_cap.value_or("unknown")},
+              .free_vram = std::stoi(n.vram_free),
+              .total_vram = std::stoi(n.vram_total),
+              .uuid = n.uuid});
+    }
+    return res;
+  }
 }
 }  // namespace cortex::hw


### PR DESCRIPTION
## Describe Your Changes

This pull request includes updates to the `GetGPUInfo` function in the `engine/utils/hardware/gpu_info.h` file. The changes improve the handling of GPU information by incorporating additional data from Vulkan GPUs when available and ensuring that NVIDIA GPU information is used as a fallback.

Key changes include:

* Improved handling of GPU information by checking if Vulkan GPU data is available and using it if present, otherwise falling back to NVIDIA GPU data.
* Added logic to populate a vector with NVIDIA GPU information when Vulkan GPU data is not available, including details such as driver version, compute capability, and VRAM.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed