### PR TITLE
doc: Update build from source command

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ cortex-nightly hardware activate
 
 ```bash
 git clone https://github.com/janhq/cortex.cpp
+cd cortex.cpp
+git submodule update --init --recursive
 cd engine/vcpkg && ./bootstrap-vcpkg.sh
 cd ../build && cmake .. && make -j4
 ```


### PR DESCRIPTION
## Describe Your Changes

Build from source instruction is missing the command to clone submodule `vcpkg`. Doc is updated to reflect that.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed