### PR TITLE
fix: filter out llvmpipe

### DIFF
--- a/engine/common/hardware_common.h
+++ b/engine/common/hardware_common.h
@@ -100,7 +100,9 @@ inline Json::Value ToJson(const std::vector<GPU>& gpus) {
     gpu["total_vram"] = gpus[i].total_vram;
     gpu["uuid"] = gpus[i].uuid;
     gpu["activated"] = gpus[i].is_activated;
-    res.append(gpu);
+    if (gpus[i].total_vram > 0) {
+      res.append(gpu);
+    }
   }
   return res;
 }

--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -300,9 +300,9 @@ inline cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
 
   uint32_t extension_count = 0;
   vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
-  std::vector<VkExtensionProperties> availableExtensions(extension_count);
+  std::vector<VkExtensionProperties> available_extensions(extension_count);
   vkEnumerateInstanceExtensionProperties(nullptr, &extension_count,
-                                         availableExtensions.data());
+                                         available_extensions.data());
 
   // Create a Vulkan instance
   VkInstanceCreateInfo instance_create_info = {};
@@ -310,12 +310,12 @@ inline cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
   // If the extension is available, enable it
   std::vector<const char*> enabled_extensions;
 
-  for (const auto& extension : availableExtensions) {
+  for (const auto& extension : available_extensions) {
     enabled_extensions.push_back(extension.extensionName);
   }
 
   instance_create_info.enabledExtensionCount =
-      static_cast<uint32_t>(availableExtensions.size());
+      static_cast<uint32_t>(available_extensions.size());
   instance_create_info.ppEnabledExtensionNames = enabled_extensions.data();
 
   VkInstance instance;

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -8,16 +8,15 @@
 namespace cortex::hw {
 
 inline std::vector<GPU> GetGPUInfo() {
-  std::vector<GPU> res;
-  // Only support for nvidia for now
-  // auto gpus = hwinfo::getAllGPUs();
   auto nvidia_gpus = system_info_utils::GetGpuInfoList();
   auto vulkan_gpus = GetGpuInfoList().value_or(std::vector<cortex::hw::GPU>{});
-  // add more information for GPUs
+  auto use_vulkan_info = nvidia_gpus.empty();
 
+  // In case we have vulkan info, add more information for GPUs
   for (size_t i = 0; i < nvidia_gpus.size(); i++) {
     for (size_t j = 0; j < vulkan_gpus.size(); j++) {
       if (nvidia_gpus[i].uuid.find(vulkan_gpus[j].uuid) != std::string::npos) {
+        use_vulkan_info = true;
         vulkan_gpus[j].version =
             nvidia_gpus[0].cuda_driver_version.value_or("unknown");
         vulkan_gpus[j].add_info = NvidiaAddInfo{
@@ -28,6 +27,25 @@ inline std::vector<GPU> GetGPUInfo() {
       }
     }
   }
-  return vulkan_gpus;
+  
+  if (use_vulkan_info) {
+    return vulkan_gpus;
+  } else {
+    std::vector<GPU> res;
+    for (auto& n : nvidia_gpus) {
+      res.emplace_back(
+          GPU{.id = n.id,
+              .name = n.name,
+              .version = nvidia_gpus[0].cuda_driver_version.value_or("unknown"),
+              .add_info =
+                  NvidiaAddInfo{
+                      .driver_version = n.driver_version.value_or("unknown"),
+                      .compute_cap = n.compute_cap.value_or("unknown")},
+              .free_vram = std::stoi(n.vram_free),
+              .total_vram = std::stoi(n.vram_total),
+              .uuid = n.uuid});
+    }
+    return res;
+  }
 }
 }  // namespace cortex::hw


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to improve GPU information handling and code readability in the `engine` module. The most important changes include adding a condition to append GPU information only if `total_vram` is greater than zero, renaming variables for better readability, and enhancing the logic to handle GPU information from different sources.

### Improvements to GPU Information Handling:

* [`engine/common/hardware_common.h`](diffhunk://#diff-adc20b97e31aa35d61ede3a2523f0126b79c4f0a2008165890d01e5ba9a6f335R103-R106): Added a condition to append GPU information to the result only if `total_vram` is greater than zero.

### Code Readability Enhancements:

* [`engine/utils/hardware/gpu/vulkan/vulkan_gpu.h`](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L303-R318): Renamed variables from `availableExtensions` to `available_extensions` for better readability and consistency.

### Enhancements to GPU Information Logic:

* [`engine/utils/hardware/gpu_info.h`](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413L11-R19): Modified the logic to determine whether to use Vulkan information by introducing the `use_vulkan_info` flag and returning appropriate GPU information based on its value. [[1]](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413L11-R19) [[2]](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413R30-R49)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed