### PR TITLE
fix: correct get server name method

### DIFF
--- a/engine/utils/file_manager_utils.cc
+++ b/engine/utils/file_manager_utils.cc
@@ -17,14 +17,15 @@
 #endif
 
 namespace file_manager_utils {
-std::filesystem::path GetExecutableFolderContainerPath() {
+
+std::filesystem::path GetExecutablePath() {
 #if defined(__APPLE__) && defined(__MACH__)
   char buffer[1024];
   uint32_t size = sizeof(buffer);
 
   if (_NSGetExecutablePath(buffer, &size) == 0) {
     // CTL_DBG("Executable path: " << buffer);
-    return std::filesystem::path{buffer}.parent_path();
+    return std::filesystem::path{buffer};
   } else {
     CTL_ERR("Failed to get executable path");
     return std::filesystem::current_path();
@@ -35,7 +36,7 @@ std::filesystem::path GetExecutableFolderContainerPath() {
   if (len != -1) {
     buffer[len] = '\0';
     // CTL_DBG("Executable path: " << buffer);
-    return std::filesystem::path{buffer}.parent_path();
+    return std::filesystem::path{buffer};
   } else {
     CTL_ERR("Failed to get executable path");
     return std::filesystem::current_path();
@@ -44,11 +45,15 @@ std::filesystem::path GetExecutableFolderContainerPath() {
   wchar_t buffer[MAX_PATH];
   GetModuleFileNameW(NULL, buffer, MAX_PATH);
   // CTL_DBG("Executable path: " << buffer);
-  return std::filesystem::path{buffer}.parent_path();
+  return std::filesystem::path{buffer};
 #else
   LOG_ERROR << "Unsupported platform!";
   return std::filesystem::current_path();
 #endif
+}
+
+std::filesystem::path GetExecutableFolderContainerPath() {
+  return GetExecutablePath().parent_path();
 }
 
 std::filesystem::path GetHomeDirectoryPath() {

--- a/engine/utils/file_manager_utils.h
+++ b/engine/utils/file_manager_utils.h
@@ -20,6 +20,8 @@ inline std::string cortex_config_file_path;
 
 inline std::string cortex_data_folder_path;
 
+std::filesystem::path GetExecutablePath();
+
 std::filesystem::path GetExecutableFolderContainerPath();
 
 std::filesystem::path GetHomeDirectoryPath();


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to the `HardwareService::Restart` function and the `file_manager_utils` utilities to improve the handling of executable paths. The most important changes include updating the method for obtaining the executable path, adding debug logging, and modifying the `Restart` function to use the new utility methods.

Improvements to executable path handling:

* [`engine/utils/file_manager_utils.cc`](diffhunk://#diff-182a2b8f0babc0c34da412dd752854c9633c55ee73996d6e20caf79731aca0c2L20-R28): Replaced `GetExecutableFolderContainerPath` with `GetExecutablePath` and added a new method `GetExecutableFolderContainerPath` that calls `GetExecutablePath().parent_path()`. [[1]](diffhunk://#diff-182a2b8f0babc0c34da412dd752854c9633c55ee73996d6e20caf79731aca0c2L20-R28) [[2]](diffhunk://#diff-182a2b8f0babc0c34da412dd752854c9633c55ee73996d6e20caf79731aca0c2L38-R39) [[3]](diffhunk://#diff-182a2b8f0babc0c34da412dd752854c9633c55ee73996d6e20caf79731aca0c2L47-R58)

Updates to `HardwareService::Restart` function:

* [`engine/services/hardware_service.cc`](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956L63-R64): Updated the `exe` variable to use `file_manager_utils::Subtract(file_manager_utils::GetExecutablePath(), cortex_utils::GetCurrentPath())` instead of `commands::GetCortexServerBinary()`.
* [`engine/services/hardware_service.cc`](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956L150-R155): Changed the conversion of `exe` to a wide string using `exe.wstring()` instead of `cortex::wc::Utf8ToWstring(exe)`.
* [`engine/services/hardware_service.cc`](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956L203-R206): Updated the server file path to use `exe.string()` and added debug logging for the server file path.

Header file updates:

* [`engine/utils/file_manager_utils.h`](diffhunk://#diff-bb81bcff5306a8f792188379d8575add8805d681d84ede56898e671d46a68631R23-R24): Added declaration for the new `GetExecutablePath` method.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed