### PR TITLE
fix: map nvidia and vulkan uuid

### DIFF
--- a/engine/services/hardware_service.cc
+++ b/engine/services/hardware_service.cc
@@ -491,7 +491,7 @@ std::vector<int> HardwareService::GetCudaConfig() {
   // Map uuid back to nvidia id
   for (auto const& uuid : uuids) {
     for (auto const& ngpu : nvidia_gpus) {
-      if (uuid == ngpu.uuid) {
+      if (ngpu.uuid.find(uuid) != std::string::npos) {
         res.push_back(std::stoi(ngpu.id));
       }
     }

--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -421,18 +421,16 @@ inline cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
 #endif
     int free_vram_MiB =
         total_vram_MiB > used_vram_MiB ? total_vram_MiB - used_vram_MiB : 0;
-    if (total_vram_MiB > 0) {
-      gpus.emplace_back(cortex::hw::GPU{
-          .id = std::to_string(id),
-          .device_id = device_properties.deviceID,
-          .name = device_properties.deviceName,
-          .version = std::to_string(device_properties.driverVersion),
-          .add_info = cortex::hw::AmdAddInfo{},
-          .free_vram = free_vram_MiB,
-          .total_vram = total_vram_MiB,
-          .uuid = uuid_to_string(device_id_properties.deviceUUID),
-          .vendor = GetVendorStr(device_properties.vendorID)});
-    }
+    gpus.emplace_back(cortex::hw::GPU{
+        .id = std::to_string(id),
+        .device_id = device_properties.deviceID,
+        .name = device_properties.deviceName,
+        .version = std::to_string(device_properties.driverVersion),
+        .add_info = cortex::hw::AmdAddInfo{},
+        .free_vram = free_vram_MiB,
+        .total_vram = total_vram_MiB,
+        .uuid = uuid_to_string(device_id_properties.deviceUUID),
+        .vendor = GetVendorStr(device_properties.vendorID)});
     id++;
   }
 

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -29,6 +29,15 @@ inline std::vector<GPU> GetGPUInfo() {
     }
   }
 
+  // Erase invalid GPUs
+  for (std::vector<cortex::hw::GPU>::iterator it = vulkan_gpus.begin();
+       it != vulkan_gpus.end();) {
+    if ((*it).total_vram <= 0)
+      it = vulkan_gpus.erase(it);
+    else
+      ++it;
+  }
+
   if (use_vulkan_info) {
     return vulkan_gpus;
   } else {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to the GPU information retrieval and configuration logic in the hardware service and utility files. The most important changes include modifying how UUIDs are matched, removing unnecessary conditions, and filtering out invalid GPUs.

Improvements to UUID matching:

* [`engine/services/hardware_service.cc`](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956L494-R494): Changed the condition to match UUIDs using `std::string::npos` to find substrings instead of exact matches.

Codebase simplification and cleanup:

* [`engine/utils/hardware/gpu/vulkan/vulkan_gpu.h`](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L424): Removed unnecessary condition checks for `total_vram_MiB` when adding GPUs to the list. [[1]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L424) [[2]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L435)

Filtering invalid GPUs:

* [`engine/utils/hardware/gpu_info.h`](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413R32-R40): Added logic to erase GPUs with `total_vram` less than or equal to zero from the Vulkan GPU list.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed