### PR TITLE
chore: cherry-pick: permission issue for default drogon uploads folder (#1870)

### DIFF
--- a/engine/main.cc
+++ b/engine/main.cc
@@ -201,6 +201,9 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
   drogon::app().registerController(hw_ctl);
   drogon::app().registerController(config_ctl);
 
+  auto upload_path = std::filesystem::temp_directory_path() / "cortex-uploads";
+  drogon::app().setUploadPath(upload_path.string());
+
   LOG_INFO << "Server started, listening at: " << config.apiServerHost << ":"
            << config.apiServerPort;
   LOG_INFO << "Please load your model";

--- a/engine/services/model_source_service.cc
+++ b/engine/services/model_source_service.cc
@@ -430,7 +430,7 @@ void ModelSourceService::SyncModelSource() {
   constexpr const int kIntervalCheck = 10 * 60;
   auto start_time = std::chrono::steady_clock::now();
   while (running_) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     auto current_time = std::chrono::steady_clock::now();
     auto elapsed_time = std::chrono::duration_cast<std::chrono::seconds>(
                             current_time - start_time)


### PR DESCRIPTION
## Describe Your Changes

This pull request includes an important change to the server setup in the `engine/main.cc` file. The change sets the upload path for the application to a temporary directory.

Server setup improvement:

* [`engine/main.cc`](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R204-R206): Added code to set the upload path to a temporary directory using `std::filesystem::temp_directory_path()` and `drogon::app().setUploadPath()`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed