### PR TITLE
fix: make get hardware info function thread-safe

### DIFF
--- a/engine/services/hardware_service.cc
+++ b/engine/services/hardware_service.cc
@@ -35,6 +35,7 @@ bool TryConnectToServer(const std::string& host, int port) {
 
 HardwareInfo HardwareService::GetHardwareInfo() {
   // append active state
+  std::lock_guard<std::mutex> l(mtx_);
   auto gpus = cortex::hw::GetGPUInfo();
   auto res = db_service_->LoadHardwareList();
   if (res.has_value()) {

--- a/engine/services/hardware_service.h
+++ b/engine/services/hardware_service.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "common/hardware_config.h"
 #include "database_service.h"
@@ -39,4 +40,5 @@ class HardwareService {
  private:
   std::shared_ptr<DatabaseService> db_service_ = nullptr;
   std::optional<cortex::hw::ActivateHardwareConfig> ahc_;
+  std::mutex mtx_;
 };


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `HardwareService` class to ensure thread safety by adding a mutex lock in the `GetHardwareInfo` method. The most important changes are outlined below:

Thread safety improvements:

* [`engine/services/hardware_service.cc`](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956R38): Added a `std::lock_guard<std::mutex>` to the `GetHardwareInfo` method to handle concurrent access.
* [`engine/services/hardware_service.h`](diffhunk://#diff-8c5292efcaa896418e8d5cb5a2adfbb50af4c48deffcd9a261adec4502c851a4R5): Included the `<mutex>` header to support the mutex functionality.
* [`engine/services/hardware_service.h`](diffhunk://#diff-8c5292efcaa896418e8d5cb5a2adfbb50af4c48deffcd9a261adec4502c851a4R43): Added a `std::mutex` member variable to the `HardwareService` class to manage synchronization.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed