### PR TITLE
fix: support resume download for /pull

### DIFF
--- a/engine/cli/utils/download_progress.cc
+++ b/engine/cli/utils/download_progress.cc
@@ -88,7 +88,7 @@ bool DownloadProgress::Handle(
       // Check the length of the input string
       if (str.length() >= max_length) {
         return str.substr(
-            0, max_length);  // Return truncated string if it's too long
+            0, max_length - 5) + " ... ";  // Return truncated string if it's too long
       }
 
       // Calculate the number of spaces needed

--- a/engine/common/download_task.h
+++ b/engine/common/download_task.h
@@ -91,6 +91,8 @@ struct DownloadTask {
 
   std::vector<DownloadItem> items;
 
+  bool resume;
+
   std::string ToString() const {
     std::ostringstream output;
     output << "DownloadTask{id: " << id << ", type: " << static_cast<int>(type)

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -45,6 +45,7 @@ void Models::PullModel(const HttpRequestPtr& req,
 
   std::optional<std::string> desired_model_name = std::nullopt;
   auto name_value = (*(req->getJsonObject())).get("name", "").asString();
+  auto resume = (*(req->getJsonObject())).get("resume", true).asBool();
 
   if (!name_value.empty()) {
     desired_model_name = name_value;
@@ -55,7 +56,7 @@ void Models::PullModel(const HttpRequestPtr& req,
     CTL_INF("Handle model input, model handle: " + model_handle);
     if (string_utils::StartsWith(model_handle, "https")) {
       return model_service_->HandleDownloadUrlAsync(
-          model_handle, desired_model_id, desired_model_name);
+          model_handle, desired_model_id, desired_model_name, resume);
     } else if (model_handle.find(":") != std::string::npos) {
       auto model_and_branch = string_utils::SplitBy(model_handle, ":");
       if (model_and_branch.size() == 3) {
@@ -69,11 +70,11 @@ void Models::PullModel(const HttpRequestPtr& req,
                 "main",
                 model_and_branch[2],
             }}.ToFullPath();
-        return model_service_->HandleDownloadUrlAsync(mh, desired_model_id,
-                                                      desired_model_name);
+        return model_service_->HandleDownloadUrlAsync(
+            mh, desired_model_id, desired_model_name, resume);
       }
       return model_service_->DownloadModelFromCortexsoAsync(
-          model_and_branch[0], model_and_branch[1], desired_model_id);
+          model_and_branch[0], model_and_branch[1], desired_model_id, resume);
     }
 
     return cpp::fail("Invalid model handle or not supported!");

--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -368,14 +368,16 @@ cpp::result<void, std::string> EngineService::DownloadEngine(
     CTL_INF("Finished!");
   };
 
-  auto downloadTask =
-      DownloadTask{.id = selected_variant->name,
-                   .type = DownloadType::Engine,
-                   .items = {DownloadItem{
-                       .id = selected_variant->name,
-                       .downloadUrl = selected_variant->browser_download_url,
-                       .localPath = variant_path,
-                   }}};
+  auto downloadTask = DownloadTask{
+      .id = selected_variant->name,
+      .type = DownloadType::Engine,
+      .items = {DownloadItem{
+          .id = selected_variant->name,
+          .downloadUrl = selected_variant->browser_download_url,
+          .localPath = variant_path,
+      }},
+      .resume = false,
+  };
 
   auto add_task_result = download_service_->AddTask(downloadTask, on_finished);
   if (add_task_result.has_error()) {
@@ -425,6 +427,7 @@ cpp::result<bool, std::string> EngineService::DownloadCuda(
       .items = {DownloadItem{.id = download_id,
                              .downloadUrl = cuda_toolkit_url,
                              .localPath = cuda_toolkit_local_path}},
+      .resume = false,
   }};
 
   auto on_finished = [engine](const DownloadTask& finishedTask) {

--- a/engine/services/model_service.h
+++ b/engine/services/model_service.h
@@ -74,8 +74,6 @@ class ModelService {
   cpp::result<ModelPullInfo, std::string> GetModelPullInfo(
       const std::string& model_handle);
 
-  cpp::result<std::string, std::string> HandleUrl(const std::string& url);
-
   cpp::result<DownloadTask, std::string> HandleDownloadUrlAsync(
       const std::string& url, std::optional<std::string> temp_model_id,
       std::optional<std::string> temp_name, bool resume = true);
@@ -95,12 +93,6 @@ class ModelService {
   std::string GetEngineByModelId(const std::string& model_id) const;
 
  private:
-  /**
-   * Handle downloading model which have following pattern: author/model_name
-   */
-  cpp::result<std::string, std::string> DownloadHuggingFaceGgufModel(
-      const std::string& author, const std::string& modelName,
-      std::optional<std::string> fileName);
 
   /**
    * Handling cortexso models. Will look through cortexso's HF repository and

--- a/engine/services/model_service.h
+++ b/engine/services/model_service.h
@@ -50,7 +50,8 @@ class ModelService {
 
   cpp::result<DownloadTask, std::string> DownloadModelFromCortexsoAsync(
       const std::string& name, const std::string& branch = "main",
-      std::optional<std::string> temp_model_id = std::nullopt);
+      std::optional<std::string> temp_model_id = std::nullopt,
+      bool resume = true);
 
   std::optional<config::ModelConfig> GetDownloadedModel(
       const std::string& modelId) const;
@@ -77,7 +78,7 @@ class ModelService {
 
   cpp::result<DownloadTask, std::string> HandleDownloadUrlAsync(
       const std::string& url, std::optional<std::string> temp_model_id,
-      std::optional<std::string> temp_name);
+      std::optional<std::string> temp_name, bool resume = true);
 
   bool HasModel(const std::string& id) const;
 
@@ -111,6 +112,9 @@ class ModelService {
   cpp::result<std::optional<std::string>, std::string> MayFallbackToCpu(
       const std::string& model_path, int ngl, int ctx_len, int n_batch = 2048,
       int n_ubatch = 2048, const std::string& kv_cache_type = "f16");
+
+  cpp::result<DownloadTask, std::string> GetDownloadTask(
+      const std::string& modelId, const std::string& branch = "main");
 
   std::shared_ptr<DatabaseService> db_service_;
   std::shared_ptr<HardwareService> hw_service_;


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces several improvements and new features to the download service in the engine. The most important changes include adding support for resuming downloads, enhancing logging for download progress, and refactoring the `GetDownloadTask` function.

Enhancements to download functionality:

* [`engine/services/download_service.cc`](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beL379-R414): Added logic to check for existing files and resume downloads if the file is partially downloaded. This includes updating the file open mode to "ab" for appending and setting the `CURLOPT_RESUME_FROM_LARGE` option in `SetUpCurlHandle` to resume downloads. [[1]](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beL379-R414) [[2]](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beL392-R428) [[3]](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beL461-R498) [[4]](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beR507-R514)

Logging improvements:

* [`engine/services/download_service.cc`](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beL379-R414): Enhanced logging to provide more detailed information about the download process, including the size of existing files and the number of bytes needed to complete the download.

Refactoring and code cleanup:

* [`engine/services/model_service.cc`](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefL100-L143): Moved the `GetDownloadTask` function to a more appropriate location within the `ModelService` class and refactored it to include file size information for each download item. [[1]](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefL100-L143) [[2]](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefR1335-R1382)
* [`engine/services/download_service.h`](diffhunk://#diff-6bc3cca95e64dd78f621de025e388270f7e14761c1a24ffe584f5a7d532e7545L65-R65): Updated the `SetUpCurlHandle` function signature to include a `resume_download` parameter.
* [`engine/services/model_service.h`](diffhunk://#diff-3ecfd5e924f3bafa0438954ccce79404dcc5419b6ffa439eefb531f766de10a6R115-R117): Added the `GetDownloadTask` function declaration to the `ModelService` class.

Minor fixes:

* [`engine/cli/utils/download_progress.cc`](diffhunk://#diff-b2bf299540a9576d29a7f295645e4f45e1332dfb306cf403060d31bf3efee5e6L91-R91): Fixed an off-by-one error in string truncation logic.
* [`engine/services/download_service.cc`](diffhunk://#diff-6f86a6bf89657234bcc962976bee215a1fa2469780b78dc17dcac5c6696d06beR43-R44): Added handling for HTTP 206 (Partial Content) response code in `ProcessCompletedTransfers`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed