### PR TITLE
fix: cache data for gpu information

### DIFF
--- a/engine/utils/hardware/cpu_info.h
+++ b/engine/utils/hardware/cpu_info.h
@@ -16,7 +16,16 @@ inline CPU GetCPUInfo() {
     return CPU{};
   auto cpu = res[0];
   cortex::cpuid::CpuInfo inst;
+
+#if defined(__linux__)
+  float usage = 0;
+  for (auto const& c : res) {
+    usage += c.currentUtilisation();
+  }
+  usage = usage / res.size() * 100;
+#else
   float usage = GetCPUUsage();
+#endif
   // float usage = 0;
   return CPU{.cores = cpu.numPhysicalCores(),
              .arch = std::string(GetArch()),

--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -251,193 +251,221 @@ inline int FreeLibrary(void* pLibrary) {
 }
 #endif
 
-inline cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
-  namespace fmu = file_manager_utils;
-  auto get_vulkan_path = [](const std::string& lib_vulkan)
-      -> cpp::result<std::filesystem::path, std::string> {
-    if (std::filesystem::exists(fmu::GetExecutableFolderContainerPath() /
-                                lib_vulkan)) {
-      return fmu::GetExecutableFolderContainerPath() / lib_vulkan;
-      // fallback to deps path
-    } else if (std::filesystem::exists(fmu::GetCortexDataPath() / "deps" /
-                                       lib_vulkan)) {
-      return fmu::GetCortexDataPath() / "deps" / lib_vulkan;
-    } else {
-      CTL_WRN("Could not found " << lib_vulkan);
-      return cpp::fail("Could not found " + lib_vulkan);
-    }
-  };
+class VulkanGpu {
+ private:
+  VulkanGpu() {}
+#if defined(__linux__) || defined(__APPLE__)
+  void* vulkan_library = nullptr;
+#else
+  HMODULE vulkan_library = nullptr;
+#endif
+
+ public:
+  VulkanGpu(VulkanGpu const&) = delete;
+  VulkanGpu& operator=(VulkanGpu const&) = delete;
+  ~VulkanGpu() {
+    if (vulkan_library)
+      FreeLibrary(vulkan_library);
+  }
+
+  static VulkanGpu& GetInstance() {
+    static VulkanGpu vg;
+    return vg;
+  }
+
+  cpp::result<std::vector<cortex::hw::GPU>, std::string> GetGpuInfoList() {
+    namespace fmu = file_manager_utils;
+    auto get_vulkan_path = [](const std::string& lib_vulkan)
+        -> cpp::result<std::filesystem::path, std::string> {
+      if (std::filesystem::exists(fmu::GetExecutableFolderContainerPath() /
+                                  lib_vulkan)) {
+        return fmu::GetExecutableFolderContainerPath() / lib_vulkan;
+        // fallback to deps path
+      } else if (std::filesystem::exists(fmu::GetCortexDataPath() / "deps" /
+                                         lib_vulkan)) {
+        return fmu::GetCortexDataPath() / "deps" / lib_vulkan;
+      } else {
+        CTL_WRN("Could not found " << lib_vulkan);
+        return cpp::fail("Could not found " + lib_vulkan);
+      }
+    };
 // Load the Vulkan library
 #if defined(__APPLE__) && defined(__MACH__)
-  return std::vector<cortex::hw::GPU>{};
+    return std::vector<cortex::hw::GPU>{};
 #elif defined(__linux__)
-  auto vulkan_path = get_vulkan_path("libvulkan.so");
-  if (vulkan_path.has_error()) {
-    return cpp::fail(vulkan_path.error());
-  }
-  void* vulkan_library =
-      dlopen(vulkan_path.value().string().c_str(), RTLD_LAZY | RTLD_GLOBAL);
+    auto vulkan_path = get_vulkan_path("libvulkan.so");
+    if (vulkan_path.has_error()) {
+      return cpp::fail(vulkan_path.error());
+    }
+    if (vulkan_library == nullptr) {
+      vulkan_library =
+          dlopen(vulkan_path.value().string().c_str(), RTLD_LAZY | RTLD_GLOBAL);
+    }
 #else
-  auto vulkan_path = get_vulkan_path("vulkan-1.dll");
-  if (vulkan_path.has_error()) {
-    return cpp::fail(vulkan_path.error());
-  }
-  HMODULE vulkan_library = LoadLibraryW(vulkan_path.value().wstring().c_str());
+    auto vulkan_path = get_vulkan_path("vulkan-1.dll");
+    if (vulkan_path.has_error()) {
+      return cpp::fail(vulkan_path.error());
+    }
+    if (vulkan_library == nullptr) {
+      vulkan_library = LoadLibraryW(vulkan_path.value().wstring().c_str());
+    }
 #endif
 #if defined(_WIN32) || defined(_WIN64) || defined(__linux__)
-  if (!vulkan_library) {
-    std::cerr << "Failed to load the Vulkan library." << std::endl;
-    return cpp::fail("Failed to load the Vulkan library.");
-  }
+    if (!vulkan_library) {
+      std::cerr << "Failed to load the Vulkan library." << std::endl;
+      return cpp::fail("Failed to load the Vulkan library.");
+    }
 
-  // Get the function pointers for other Vulkan functions
-  auto vkEnumerateInstanceExtensionProperties =
-      reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(
-          GetProcAddress(vulkan_library,
-                         "vkEnumerateInstanceExtensionProperties"));
-  auto vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(
-      GetProcAddress(vulkan_library, "vkCreateInstance"));
-  auto vkEnumeratePhysicalDevices =
-      reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(
-          GetProcAddress(vulkan_library, "vkEnumeratePhysicalDevices"));
-  auto vkGetPhysicalDeviceProperties =
-      reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(
-          GetProcAddress(vulkan_library, "vkGetPhysicalDeviceProperties"));
-  auto vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(
-      GetProcAddress(vulkan_library, "vkDestroyInstance"));
-  auto vkGetPhysicalDeviceMemoryProperties =
-      (PFN_vkGetPhysicalDeviceMemoryProperties)GetProcAddress(
-          vulkan_library, "vkGetPhysicalDeviceMemoryProperties");
+    // Get the function pointers for other Vulkan functions
+    auto vkEnumerateInstanceExtensionProperties =
+        reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(
+            GetProcAddress(vulkan_library,
+                           "vkEnumerateInstanceExtensionProperties"));
+    auto vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(
+        GetProcAddress(vulkan_library, "vkCreateInstance"));
+    auto vkEnumeratePhysicalDevices =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(
+            GetProcAddress(vulkan_library, "vkEnumeratePhysicalDevices"));
+    auto vkGetPhysicalDeviceProperties =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(
+            GetProcAddress(vulkan_library, "vkGetPhysicalDeviceProperties"));
+    auto vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(
+        GetProcAddress(vulkan_library, "vkDestroyInstance"));
+    auto vkGetPhysicalDeviceMemoryProperties =
+        (PFN_vkGetPhysicalDeviceMemoryProperties)GetProcAddress(
+            vulkan_library, "vkGetPhysicalDeviceMemoryProperties");
 
-  auto vkGetPhysicalDeviceProperties2 =
-      (PFN_vkGetPhysicalDeviceProperties2)GetProcAddress(
-          vulkan_library, "vkGetPhysicalDeviceProperties2");
+    auto vkGetPhysicalDeviceProperties2 =
+        (PFN_vkGetPhysicalDeviceProperties2)GetProcAddress(
+            vulkan_library, "vkGetPhysicalDeviceProperties2");
 
-  uint32_t extension_count = 0;
-  vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
-  std::vector<VkExtensionProperties> available_extensions(extension_count);
-  vkEnumerateInstanceExtensionProperties(nullptr, &extension_count,
-                                         available_extensions.data());
+    uint32_t extension_count = 0;
+    vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
+    std::vector<VkExtensionProperties> available_extensions(extension_count);
+    vkEnumerateInstanceExtensionProperties(nullptr, &extension_count,
+                                           available_extensions.data());
 
-  // Create a Vulkan instance
-  VkInstanceCreateInfo instance_create_info = {};
-  instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-  // If the extension is available, enable it
-  std::vector<const char*> enabled_extensions;
+    // Create a Vulkan instance
+    VkInstanceCreateInfo instance_create_info = {};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    // If the extension is available, enable it
+    std::vector<const char*> enabled_extensions;
 
-  for (const auto& extension : available_extensions) {
-    enabled_extensions.push_back(extension.extensionName);
-  }
+    for (const auto& extension : available_extensions) {
+      enabled_extensions.push_back(extension.extensionName);
+    }
 
-  instance_create_info.enabledExtensionCount =
-      static_cast<uint32_t>(available_extensions.size());
-  instance_create_info.ppEnabledExtensionNames = enabled_extensions.data();
+    instance_create_info.enabledExtensionCount =
+        static_cast<uint32_t>(available_extensions.size());
+    instance_create_info.ppEnabledExtensionNames = enabled_extensions.data();
 
-  VkInstance instance;
-  if (vkCreateInstance == nullptr || vkEnumeratePhysicalDevices == nullptr ||
-      vkGetPhysicalDeviceProperties == nullptr ||
-      vkDestroyInstance == nullptr ||
-      vkGetPhysicalDeviceMemoryProperties == nullptr ||
-      vkGetPhysicalDeviceProperties2 == nullptr) {
-    return cpp::fail("vulkan API is missing!");
-  }
+    VkInstance instance;
+    if (vkCreateInstance == nullptr || vkEnumeratePhysicalDevices == nullptr ||
+        vkGetPhysicalDeviceProperties == nullptr ||
+        vkDestroyInstance == nullptr ||
+        vkGetPhysicalDeviceMemoryProperties == nullptr ||
+        vkGetPhysicalDeviceProperties2 == nullptr) {
+      return cpp::fail("vulkan API is missing!");
+    }
 
-  VkResult result = vkCreateInstance(&instance_create_info, nullptr, &instance);
-  if (result != VK_SUCCESS) {
-    FreeLibrary(vulkan_library);
-    return cpp::fail("Failed to create a Vulkan instance.");
-  }
+    VkResult result =
+        vkCreateInstance(&instance_create_info, nullptr, &instance);
+    if (result != VK_SUCCESS) {
+      FreeLibrary(vulkan_library);
+      return cpp::fail("Failed to create a Vulkan instance.");
+    }
 
-  // Get the physical devices
-  uint32_t physical_device_count = 0;
-  result =
-      vkEnumeratePhysicalDevices(instance, &physical_device_count, nullptr);
-  if (result != VK_SUCCESS) {
+    // Get the physical devices
+    uint32_t physical_device_count = 0;
+    result =
+        vkEnumeratePhysicalDevices(instance, &physical_device_count, nullptr);
+    if (result != VK_SUCCESS) {
+      vkDestroyInstance(instance, nullptr);
+      FreeLibrary(vulkan_library);
+      return cpp::fail("Failed to enumerate physical devices.");
+    }
+    std::vector<VkPhysicalDevice> physical_devices(physical_device_count);
+    vkEnumeratePhysicalDevices(instance, &physical_device_count,
+                               physical_devices.data());
+
+    auto uuid_to_string = [](const uint8_t* device_uuid) -> std::string {
+      std::stringstream ss;
+      ss << std::hex << std::setfill('0');
+      for (uint32_t i = 0; i < VK_UUID_SIZE; ++i) {
+        if (i == 4 || i == 6 || i == 8 || i == 10) {
+          ss << '-';
+        }
+        ss << std::setw(2) << static_cast<int>(device_uuid[i]);
+      }
+      return ss.str();
+    };
+
+    std::vector<cortex::hw::GPU> gpus;
+#if defined(__linux__)
+    auto gpus_usages =
+        GetGpuUsage().value_or(std::unordered_map<int, AmdGpuUsage>{});
+#elif defined(_WIN32)
+    auto gpus_usages =
+        GetGpuUsage().value_or(std::unordered_map<std::string, int>{});
+#endif
+
+    // Get the device properties
+    size_t id = 0;
+    for (const auto& physical_device : physical_devices) {
+      VkPhysicalDeviceProperties device_properties;
+      vkGetPhysicalDeviceProperties(physical_device, &device_properties);
+
+      VkPhysicalDeviceIDProperties device_id_properties = {};
+      VkPhysicalDeviceProperties2 device_properties2 = {};
+      device_properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+      device_properties2.pNext = &device_id_properties;
+      device_id_properties.sType =
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+
+      vkGetPhysicalDeviceProperties2(physical_device, &device_properties2);
+
+      VkPhysicalDeviceMemoryProperties memory_properties;
+      vkGetPhysicalDeviceMemoryProperties(physical_device, &memory_properties);
+      int gpu_avail_MiB = 0;
+      for (uint32_t i = 0; i < memory_properties.memoryHeapCount; ++i) {
+        if (memory_properties.memoryHeaps[i].flags &
+            VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+          gpu_avail_MiB +=
+              memory_properties.memoryHeaps[i].size / (1024ull * 1024ull);
+        }
+      }
+
+      int64_t total_vram_MiB = 0;
+      int64_t used_vram_MiB = 0;
+
+#if defined(__linux__)
+      total_vram_MiB = gpus_usages[device_properties.deviceID].total_vram_MiB;
+      used_vram_MiB = gpus_usages[device_properties.deviceID].used_vram_MiB;
+#elif defined(_WIN32)
+      total_vram_MiB = gpu_avail_MiB;
+      used_vram_MiB = gpus_usages[device_properties.deviceName];
+
+#endif
+      int free_vram_MiB =
+          total_vram_MiB > used_vram_MiB ? total_vram_MiB - used_vram_MiB : 0;
+      gpus.emplace_back(cortex::hw::GPU{
+          .id = std::to_string(id),
+          .device_id = device_properties.deviceID,
+          .name = device_properties.deviceName,
+          .version = std::to_string(device_properties.driverVersion),
+          .add_info = cortex::hw::AmdAddInfo{},
+          .free_vram = free_vram_MiB,
+          .total_vram = total_vram_MiB,
+          .uuid = uuid_to_string(device_id_properties.deviceUUID),
+          .vendor = GetVendorStr(device_properties.vendorID)});
+      id++;
+    }
+
+    // Clean up
     vkDestroyInstance(instance, nullptr);
-    FreeLibrary(vulkan_library);
-    return cpp::fail("Failed to enumerate physical devices.");
+
+    return gpus;
+#endif
   }
-  std::vector<VkPhysicalDevice> physical_devices(physical_device_count);
-  vkEnumeratePhysicalDevices(instance, &physical_device_count,
-                             physical_devices.data());
-
-  auto uuid_to_string = [](const uint8_t* device_uuid) -> std::string {
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (uint32_t i = 0; i < VK_UUID_SIZE; ++i) {
-      if (i == 4 || i == 6 || i == 8 || i == 10) {
-        ss << '-';
-      }
-      ss << std::setw(2) << static_cast<int>(device_uuid[i]);
-    }
-    return ss.str();
-  };
-
-  std::vector<cortex::hw::GPU> gpus;
-#if defined(__linux__)
-  auto gpus_usages =
-      GetGpuUsage().value_or(std::unordered_map<int, AmdGpuUsage>{});
-#elif defined(_WIN32)
-  auto gpus_usages =
-      GetGpuUsage().value_or(std::unordered_map<std::string, int>{});
-#endif
-
-  // Get the device properties
-  size_t id = 0;
-  for (const auto& physical_device : physical_devices) {
-    VkPhysicalDeviceProperties device_properties;
-    vkGetPhysicalDeviceProperties(physical_device, &device_properties);
-
-    VkPhysicalDeviceIDProperties device_id_properties = {};
-    VkPhysicalDeviceProperties2 device_properties2 = {};
-    device_properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-    device_properties2.pNext = &device_id_properties;
-    device_id_properties.sType =
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
-
-    vkGetPhysicalDeviceProperties2(physical_device, &device_properties2);
-
-    VkPhysicalDeviceMemoryProperties memory_properties;
-    vkGetPhysicalDeviceMemoryProperties(physical_device, &memory_properties);
-    int gpu_avail_MiB = 0;
-    for (uint32_t i = 0; i < memory_properties.memoryHeapCount; ++i) {
-      if (memory_properties.memoryHeaps[i].flags &
-          VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
-        gpu_avail_MiB +=
-            memory_properties.memoryHeaps[i].size / (1024ull * 1024ull);
-      }
-    }
-
-    int64_t total_vram_MiB = 0;
-    int64_t used_vram_MiB = 0;
-
-#if defined(__linux__)
-    total_vram_MiB = gpus_usages[device_properties.deviceID].total_vram_MiB;
-    used_vram_MiB = gpus_usages[device_properties.deviceID].used_vram_MiB;
-#elif defined(_WIN32)
-    total_vram_MiB = gpu_avail_MiB;
-    used_vram_MiB = gpus_usages[device_properties.deviceName];
-
-#endif
-    int free_vram_MiB =
-        total_vram_MiB > used_vram_MiB ? total_vram_MiB - used_vram_MiB : 0;
-    gpus.emplace_back(cortex::hw::GPU{
-        .id = std::to_string(id),
-        .device_id = device_properties.deviceID,
-        .name = device_properties.deviceName,
-        .version = std::to_string(device_properties.driverVersion),
-        .add_info = cortex::hw::AmdAddInfo{},
-        .free_vram = free_vram_MiB,
-        .total_vram = total_vram_MiB,
-        .uuid = uuid_to_string(device_id_properties.deviceUUID),
-        .vendor = GetVendorStr(device_properties.vendorID)});
-    id++;
-  }
-
-  // Clean up
-  vkDestroyInstance(instance, nullptr);
-  FreeLibrary(vulkan_library);
-  return gpus;
-#endif
-}
+};
 }  // namespace cortex::hw

--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -488,8 +488,8 @@ class VulkanGpu {
 #elif defined(_WIN32)
       auto gpus_usages =
           GetGpuUsage().value_or(std::unordered_map<std::string, int>{});
-      total_vram_MiB = gpu_avail_MiB;
-      used_vram_MiB = gpus_usages[device_properties.deviceName];
+      total_vram_MiB = gpus_[i].free_vram;
+      used_vram_MiB = gpus_usages[gpus_[i].name];
 #endif
       int free_vram_MiB =
           total_vram_MiB > used_vram_MiB ? total_vram_MiB - used_vram_MiB : 0;

--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -466,8 +466,10 @@ class VulkanGpu {
   VulkanGpu(VulkanGpu const&) = delete;
   VulkanGpu& operator=(VulkanGpu const&) = delete;
   ~VulkanGpu() {
+#if defined(_WIN32) || defined(_WIN64) || defined(__linux__)
     if (vulkan_library)
       FreeLibrary(vulkan_library);
+#endif
   }
 
   static VulkanGpu& GetInstance() {

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -9,7 +9,8 @@ namespace cortex::hw {
 
 inline std::vector<GPU> GetGPUInfo() {
   auto nvidia_gpus = system_info_utils::GetGpuInfoList();
-  auto vulkan_gpus = GetGpuInfoList().value_or(std::vector<cortex::hw::GPU>{});
+  auto vulkan_gpus = VulkanGpu::GetInstance().GetGpuInfoList().value_or(
+      std::vector<cortex::hw::GPU>{});
   auto use_vulkan_info = nvidia_gpus.empty();
 
   // In case we have vulkan info, add more information for GPUs


### PR DESCRIPTION
## Describe Your Changes

This pull request includes significant changes to the GPU information retrieval process and minor updates to the CPU usage calculation. The most important changes involve the refactoring of the Vulkan GPU handling into a class and the platform-specific adjustments for CPU and GPU usage calculations.

### GPU Information Retrieval Refactoring:
* [`engine/utils/hardware/gpu/vulkan/vulkan_gpu.h`](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L254-R264): Refactored the Vulkan GPU handling into a `VulkanGpu` class, which includes initialization, cleanup, and GPU information retrieval. This change improves modularity and encapsulation. [[1]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L254-R264) [[2]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L272-R306) [[3]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L342-R367) [[4]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L358-R378) [[5]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385R459-R501)
* [`engine/utils/hardware/gpu_info.h`](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413L12-R13): Updated the GPU information retrieval to use the new `VulkanGpu` class, ensuring a singleton instance is used.

### CPU Usage Calculation:
* [`engine/utils/hardware/cpu_info.h`](diffhunk://#diff-35fd4fe9f6c2bedd7365d7ea2757f96f92a0df40681af8236bfde2cffe9bf78fR19-R28): Added platform-specific CPU usage calculation for Linux, averaging the utilization across all cores.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed