### PR TITLE
fix: handle path with space

### DIFF
--- a/engine/cli/commands/server_start_cmd.cc
+++ b/engine/cli/commands/server_start_cmd.cc
@@ -65,16 +65,16 @@ bool ServerStartCmd::Exec(const std::string& host, int port,
   si.cb = sizeof(si);
   ZeroMemory(&pi, sizeof(pi));
   std::wstring params = L"--start-server";
-  params += L" --config_file_path " +
-            file_manager_utils::GetConfigurationPath().wstring();
-  params += L" --data_folder_path " +
-            file_manager_utils::GetCortexDataPath().wstring();
+  params += L" --config_file_path \"" + 
+            file_manager_utils::GetConfigurationPath().wstring() + L"\"";
+  params += L" --data_folder_path \"" +
+            file_manager_utils::GetCortexDataPath().wstring() + L"\"";
   params += L" --loglevel " + cortex::wc::Utf8ToWstring(log_level_);
   std::wstring exe_w = cortex::wc::Utf8ToWstring(exe);
   std::wstring current_path_w =
       file_manager_utils::GetExecutableFolderContainerPath().wstring();
-  std::wstring wcmds = current_path_w + L"/" + exe_w + L" " + params;
-  CTL_DBG("wcmds: " << wcmds);
+  std::wstring wcmds = current_path_w + L"\\" + exe_w + L" " + params;
+  CTL_INF("wcmds: " << wcmds);
   std::vector<wchar_t> mutable_cmds(wcmds.begin(), wcmds.end());
   mutable_cmds.push_back(L'\0');
   // Create child process

--- a/engine/extensions/remote-engine/remote_engine.cc
+++ b/engine/extensions/remote-engine/remote_engine.cc
@@ -31,6 +31,7 @@ size_t StreamWriteCallback(char* ptr, size_t size, size_t nmemb,
   Json::Reader reader;
   if (reader.parse(chunk, check_error)) {
     CTL_WRN(chunk);
+    CTL_INF("Request: " << context->last_request);
     Json::Value status;
     status["is_done"] = true;
     status["has_error"] = true;
@@ -143,7 +144,9 @@ CurlResponse RemoteEngine::MakeStreamingChatCompletionRequest(
       "",
       config.model,
       renderer_,
-      stream_template};
+      stream_template,
+      true,
+      body};
 
   curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);

--- a/engine/extensions/remote-engine/remote_engine.h
+++ b/engine/extensions/remote-engine/remote_engine.h
@@ -25,6 +25,7 @@ struct StreamContext {
   extensions::TemplateRenderer& renderer;
   std::string stream_template;
   bool need_stop = true;
+  std::string last_request;
 };
 struct CurlResponse {
   std::string body;

--- a/engine/services/hardware_service.cc
+++ b/engine/services/hardware_service.cc
@@ -143,16 +143,16 @@ bool HardwareService::Restart(const std::string& host, int port) {
   ZeroMemory(&pi, sizeof(pi));
   // TODO (sang) write a common function for this and server_start_cmd
   std::wstring params = L"--ignore_cout";
-  params += L" --config_file_path " +
-            file_manager_utils::GetConfigurationPath().wstring();
-  params += L" --data_folder_path " +
-            file_manager_utils::GetCortexDataPath().wstring();
+  params += L" --config_file_path \"" +
+            file_manager_utils::GetConfigurationPath().wstring() + L"\"";
+  params += L" --data_folder_path \"" +
+            file_manager_utils::GetCortexDataPath().wstring() + L"\"";
   params += L" --loglevel " +
             cortex::wc::Utf8ToWstring(luh::LogLevelStr(luh::global_log_level));
   std::wstring exe_w = exe.wstring();
   std::wstring current_path_w =
       file_manager_utils::GetExecutableFolderContainerPath().wstring();
-  std::wstring wcmds = current_path_w + L"/" + exe_w + L" " + params;
+  std::wstring wcmds = current_path_w +  L"\\" + exe_w + L" " + params;
   CTL_DBG("wcmds: " << wcmds);
   std::vector<wchar_t> mutable_cmds(wcmds.begin(), wcmds.end());
   mutable_cmds.push_back(L'\0');


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to improve the handling of command parameters, enhance logging, and update the request structure in the remote engine. The most important changes are grouped by theme below.

### Command Parameters Handling:

* [`engine/cli/commands/server_start_cmd.cc`](diffhunk://#diff-08ac546f0c77a838db51c6864583926aa0421b89c6bfedaaa1d301932932a4f3L68-R77): Added quotes around file paths in command parameters to handle paths with spaces and changed the path separator from '/' to '\' for Windows compatibility.
* [`engine/services/hardware_service.cc`](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956L146-R155): Added quotes around file paths in command parameters to handle paths with spaces and changed the path separator from '/' to '\' for Windows compatibility.

### Logging Enhancements:

* [`engine/extensions/remote-engine/remote_engine.cc`](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8R34): Added logging of the last request in the `StreamWriteCallback` function to improve debugging.

### Request Structure Update:

* [`engine/extensions/remote-engine/remote_engine.cc`](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L146-R149): Updated the `MakeStreamingChatCompletionRequest` function to include additional parameters for better request handling.
* [`engine/extensions/remote-engine/remote_engine.h`](diffhunk://#diff-72c3c0234114d4eccd2555641ab0ede72d2e97e7e7066f53bac05d3b98c276faR28): Added a new member `last_request` to the `StreamContext` struct to store the last request made.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed