### PR TITLE
fix: inherit current env vars when spawning subprocess on macos

### DIFF
--- a/engine/utils/process/utils.cc
+++ b/engine/utils/process/utils.cc
@@ -1,6 +1,10 @@
 #include "utils/process/utils.h"
 #include "utils/logging_utils.h"
 
+#if defined(__APPLE__) || defined(__linux__)
+extern char **environ;  // environment variables
+#endif
+
 namespace cortex::process {
 
 std::string ConstructWindowsCommandLine(const std::vector<std::string>& args) {
@@ -81,11 +85,7 @@ pid_t SpawnProcess(const std::vector<std::string>& command) {
                                     NULL,                // file actions
                                     NULL,                // spawn attributes
                                     argv.data(),         // argument vector
-#if defined(__linux__)
                                     environ  // environment (inherit)
-#else
-                                    NULL
-#endif
     );
 
     if (spawn_result != 0) {


### PR DESCRIPTION
## Describe Your Changes

Currently only Linux inherits current env vars when spawning subprocess. Seems like Linux automatically detects `environ` variable. For MacOS, simply declare an extern variable will do the trick. Hence, this PR makes the behavior of `SpawnProcess()` more consistent across platforms. (We will need to fix it for Windows too...)

This will be required for my future work on Python engine.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed