### PR TITLE
fix: wrong check for printing error log

### DIFF
--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -320,7 +320,7 @@ cpp::result<void, std::string> EngineService::DownloadEngine(
         engine,  // engine_name
         kLocal, "", "", normalize_version, variant.value(), "Default", "");
 
-    if (create_res.has_value()) {
+    if (create_res.has_error()) {
       CTL_ERR("Failed to create engine entry: " << create_res->engine_name);
     } else {
       CTL_INF("Engine entry created successfully");


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small but important change to the error handling logic in the `EngineService::DownloadEngine` method. The change corrects the condition used to check for errors when creating an engine entry.

* [`engine/services/engine_service.cc`](diffhunk://#diff-4c0c7acfd254155d48f2cb45c2e430faec94985cdf5ce46710e0bd615eeb3366L323-R323): Changed the condition from `create_res.has_value()` to `create_res.has_error()` to properly detect and handle errors during engine entry creation.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed