### PR TITLE
fix: use updated configuration for remote model when reload

### DIFF
--- a/engine/services/inference_service.cc
+++ b/engine/services/inference_service.cc
@@ -24,8 +24,12 @@ cpp::result<void, InferResult> InferenceService::HandleChatCompletion(
     auto status = std::get<0>(ir)["status_code"].asInt();
     if (status != drogon::k200OK) {
       CTL_INF("Model is not loaded, start loading it: " << model_id);
-      auto res = LoadModel(saved_models_.at(model_id));
-      // ignore return result
+      // For remote engine, we use the updated configuration
+      if (engine_service_->IsRemoteEngine(engine_type)) {
+        (void)model_service_.lock()->StartModel(model_id, {}, false);
+      } else {
+        (void)LoadModel(saved_models_.at(model_id));
+      }
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `InferenceService` class in the `engine/services/inference_service.cc` file. The change modifies the way models are loaded based on whether the engine is remote or not.

Changes in model loading logic:

* [`engine/services/inference_service.cc`](diffhunk://#diff-e165ef8bee4fa9dfd1a2d044abdc345eb7784ee2708a14cd582cb33ec9beceb0L27-R32): Updated the `HandleChatCompletion` method to conditionally use `StartModel` for remote engines and `LoadModel` for local engines.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed