### PR TITLE
fix: correct engine interface order

### DIFF
--- a/engine/cortex-common/EngineI.h
+++ b/engine/cortex-common/EngineI.h
@@ -59,6 +59,9 @@ class EngineI {
                              const std::string& log_path) = 0;
   virtual void SetLogLevel(trantor::Logger::LogLevel logLevel) = 0;
 
+  // Stop inflight chat completion in stream mode
+  virtual void StopInferencing(const std::string& model_id) = 0;
+
   virtual Json::Value GetRemoteModels() = 0;
   virtual void HandleRouteRequest(
       std::shared_ptr<Json::Value> json_body,
@@ -66,7 +69,4 @@ class EngineI {
   virtual void HandleInference(
       std::shared_ptr<Json::Value> json_body,
       std::function<void(Json::Value&&, Json::Value&&)>&& callback) = 0;
-
-  // Stop inflight chat completion in stream mode
-  virtual void StopInferencing(const std::string& model_id) = 0;
 };


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `engine/cortex-common/EngineI.h` file. The change repositions the `StopInferencing` method to a different location within the class definition to improve code organization.

Reorganization of methods:

* [`engine/cortex-common/EngineI.h`](diffhunk://#diff-7c6a27ed9e34fc07f57d53bf3a8604da962990a9e1a0fc21f9ec0a30c684c9ccR62-L71): Moved the `StopInferencing` method to a new position within the class definition to improve code organization.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed