### PR TITLE
fix: improve error handling for remote engine

### DIFF
--- a/engine/extensions/remote-engine/remote_engine.cc
+++ b/engine/extensions/remote-engine/remote_engine.cc
@@ -29,7 +29,11 @@ size_t StreamWriteCallback(char* ptr, size_t size, size_t nmemb,
   CTL_DBG(chunk);
   Json::Value check_error;
   Json::Reader reader;
-  if (reader.parse(chunk, check_error)) {
+  context->chunks += chunk;
+  if (reader.parse(context->chunks, check_error) ||
+      (reader.parse(chunk, check_error) &&
+       chunk.find("error") != std::string::npos)) {
+    CTL_WRN(context->chunks);
     CTL_WRN(chunk);
     CTL_INF("Request: " << context->last_request);
     Json::Value status;

--- a/engine/extensions/remote-engine/remote_engine.h
+++ b/engine/extensions/remote-engine/remote_engine.h
@@ -26,6 +26,7 @@ struct StreamContext {
   std::string stream_template;
   bool need_stop = true;
   std::string last_request;
+  std::string chunks;
 };
 struct CurlResponse {
   std::string body;


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `engine/extensions/remote-engine` to improve the handling of streamed data and error checking in the `StreamWriteCallback` function. The most important changes include modifying the `StreamWriteCallback` function to accumulate chunks of data and updating the `StreamContext` structure to support this new functionality.

Improvements to data handling and error checking:

* [`engine/extensions/remote-engine/remote_engine.cc`](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L32-R34): Modified the `StreamWriteCallback` function to accumulate chunks of data in the `context->chunks` variable and added an additional error check using the accumulated chunks.
* [`engine/extensions/remote-engine/remote_engine.h`](diffhunk://#diff-72c3c0234114d4eccd2555641ab0ede72d2e97e7e7066f53bac05d3b98c276faR29): Added a new `std::string chunks` member to the `StreamContext` structure to store accumulated chunks of data.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed