### PR TITLE
fix: temporarily remove model setting recommendation

### DIFF
--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -204,10 +204,11 @@ void Models::ListModel(
           obj["id"] = model_entry.model;
           obj["model"] = model_entry.model;
           obj["status"] = "downloaded";
-          auto es = model_service_->GetEstimation(model_entry.model);
-          if (es.has_value() && !!es.value()) {
-            obj["recommendation"] = hardware::ToJson(*(es.value()));
-          }
+          // TODO(sang) Temporarily remove this estimation
+          // auto es = model_service_->GetEstimation(model_entry.model);
+          // if (es.has_value() && !!es.value()) {
+          //   obj["recommendation"] = hardware::ToJson(*(es.value()));
+          // }
           data.append(std::move(obj));
           yaml_handler.Reset();
         } else if (model_config.engine == kPythonEngine) {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `Models::ListModel` method in the `engine/controllers/models.cc` file. The change temporarily removes the estimation logic for model entries.

* [`engine/controllers/models.cc`](diffhunk://#diff-3318b780616ed76cc8983db3e058691572ab10b81522947962d5e107cc171fc8L207-R211): Commented out the code that retrieves and adds estimation data to the model entry object.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1988

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed