### PR TITLE
fix: remove all yml files when delete model

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,12 +5,14 @@
 echo "apiServerHost: 0.0.0.0" > /root/.cortexrc
 echo "enableCors: true" >> /root/.cortexrc
 
+# Start the cortex server
+cortex start
+
 # Install the engine
 cortex engines install llama-cpp -s /opt/cortex.llamacpp
 
-# Start the cortex server
-cortex start
 cortex engines list
+
 
 # Keep the container running by tailing the log files
 tail -f /root/cortexcpp/logs/cortex.log &

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -736,8 +736,15 @@ cpp::result<void, std::string> ModelService::DeleteModel(
         fs::path(model_entry.value().path_to_model_yaml));
     yaml_handler.ModelConfigFromFile(yaml_fp.string());
     auto mc = yaml_handler.GetModelConfig();
-    // Remove yaml file
-    std::filesystem::remove(yaml_fp);
+    // Remove yaml files
+    for (const auto& entry :
+         std::filesystem::directory_iterator(yaml_fp.parent_path())) {
+      if (entry.is_regular_file() && (entry.path().extension() == ".yml")) {
+        std::filesystem::remove(entry);
+        CTL_INF("Removed: " << entry.path().string());
+      }
+    }
+
     // Remove model files if they are not imported locally
     if (model_entry.value().branch_name != "imported" &&
         !engine_svc_->IsRemoteEngine(mc.engine)) {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `ModelService::DeleteModel` method in `engine/services/model_service.cc` to improve the deletion process of YAML files associated with a model. The most important change is the modification of the code to remove all YAML files in the directory instead of just a single file.

Improvements to file deletion:

* [`engine/services/model_service.cc`](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefL739-R747): Updated the `ModelService::DeleteModel` method to iterate over the directory and remove all files with a `.yml` extension, ensuring that all relevant YAML files are deleted.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/1881

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed