### PR TITLE
Fix: Prevent Path Traversal in File Storage

### DIFF
--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -10,8 +10,8 @@ std::filesystem::path FileFsRepository::GetFilePath() const {
   return data_folder_path_ / kFileContainerFolderName;
 }
 
-std::filesystem::path SanitizePath(const std::string & user_input,
-                                    const std::string & basedir) {
+std::filesystem::path SanitizePath(const std::filesystem::path & user_input,
+                                    const std::filesystem::path & basedir) {
 
   std::filesystem::path abs_base = std::filesystem::canonical(basedir);
   std::filesystem::path resolved_path = std::filesystem::weakly_canonical(

--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -13,7 +13,7 @@ std::filesystem::path FileFsRepository::GetFilePath() const {
 std::filesystem::path SanitizePath(const std::filesystem::path & user_input,
                                     const std::filesystem::path & basedir) {
 
-  std::filesystem::path abs_base = std::filesystem::canonical(basedir);
+  auto abs_base = std::filesystem::canonical(basedir);
   std::filesystem::path resolved_path = std::filesystem::weakly_canonical(
       std::filesystem::path(basedir) / std::filesystem::path(user_input));
       /* Ensure the resolved path is within our basedir */

--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -17,8 +17,10 @@ std::filesystem::path SanitizePath(const std::filesystem::path & user_input,
   std::filesystem::path resolved_path = std::filesystem::weakly_canonical(
       std::filesystem::path(basedir) / std::filesystem::path(user_input));
       /* Ensure the resolved path is within our basedir */
-  if (resolved_path.string().find(abs_base.string()) != 0) {
-    return {};
+  for (auto p = resolved_path; !p.empty(); p = p.parent_path()) {
+    if (std::filesystem::equivalent(p, abs_base)) {
+      return resolved_path;
+    }
   }
 
   return resolved_path;

--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -21,9 +21,8 @@ std::filesystem::path SanitizePath(const std::filesystem::path & user_input,
     if (std::filesystem::equivalent(p, abs_base)) {
       return resolved_path;
     }
-  }
-
-  return resolved_path;
+  } 
+  return {};
 }
 
 cpp::result<void, std::string> FileFsRepository::StoreFile(


### PR DESCRIPTION
## Describe Your Changes
This PR introduces a sanitizer function that ensures user-provided filenames do not lead to path traversal vulnerabilities by ensuring the path is within our base directory.

cc: @supriza
## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed