### PR TITLE
Fix: Prevent Out-of-Bounds Reads in GGUF Parser

### DIFF
--- a/engine/config/gguf_parser.cc
+++ b/engine/config/gguf_parser.cc
@@ -104,6 +104,10 @@ std::pair<std::size_t, std::string> GGUFHandler::ReadString(
   uint64_t length;
   std::memcpy(&length, data_ + offset, sizeof(uint64_t));
 
+  if (offset + 8 + length > file_size_) {
+    throw std::runtime_error("GGUF metadata string length exceeds file size.\n");
+  }
+
   std::string value(reinterpret_cast<const char*>(data_ + offset + 8), length);
   return {8 + static_cast<std::size_t>(length), value};
 }
@@ -274,6 +278,9 @@ size_t GGUFHandler::ReadArray(std::size_t offset, const std::string& key) {
     }
 
     array_offset += length;
+    if (offset + array_offset > file_size_) {
+      throw std::runtime_error("GGUF Parser Array exceeded file size.\n");
+    }
   }
   if (array_values_string.size() > 0)
     metadata_array_string_[key] = array_values_string;


### PR DESCRIPTION
## Describe Your Changes
This PR adds bounds checking to prevent out-of-bounds memory access when parsing GGUF metadata strings and arrays. Previously, malformed or corrupted GGUF files could cause the parser to read beyond the allocated data buffer, potentially leading to crashes or undefined behavior.


## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

Thanks to @supriza for the report!