### PR TITLE
chore: remove hard-coded engine value in `cortex ps`

### DIFF
--- a/engine/cli/commands/ps_cmd.cc
+++ b/engine/cli/commands/ps_cmd.cc
@@ -27,7 +27,8 @@ void PsCmd::Exec(const std::string& host, int port) {
     for (const auto& item : res.value()["data"]) {
       ModelLoadedStatus model_status;
       // TODO(sang) hardcode for now
-      model_status.engine = kLlamaEngine;
+      model_status.engine = item["engine"].isNull()
+                            ? kLlamaEngine : item["engine"].asString();
       model_status.model = item["id"].asString();
       model_status.ram = item["ram"].asUInt64();
       model_status.start_time = item["start_time"].asUInt64();


### PR DESCRIPTION
## Describe Your Changes

Remove hard-coded engine value in `cortex ps`. It still defaults to llama-cpp when `engine` field is missing.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed