### PR TITLE
fix: block `command` field changes for python engine

### DIFF
--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -385,6 +385,10 @@ void Models::UpdateModel(const HttpRequestPtr& req,
       message = "Successfully update model ID '" + model_id +
                 "': " + json_body.toStyledString();
     } else if (model_config.engine == kPythonEngine) {
+      // Block changes to `command`
+      if (json_body.isMember("command")) {
+        json_body.removeMember("command");
+      }
       config::PythonModelConfig python_model_config;
       python_model_config.ReadFromYaml(yaml_fp.string());
       python_model_config.FromJson(json_body);


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `Models::UpdateModel` method in the `engine/controllers/models.cc` file. The change prevents modifications to the `command` field in the JSON body when the model configuration engine is set to `kPythonEngine`.

* [`engine/controllers/models.cc`](diffhunk://#diff-3318b780616ed76cc8983db3e058691572ab10b81522947962d5e107cc171fc8R388-R391): Added a check to block changes to the `command` field in the JSON body when the model configuration engine is `kPythonEngine`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed