### PR TITLE
chore: add /v1/models/hub endpoint

### DIFF
--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -168,32 +168,9 @@ void Models::AbortPullModel(
   }
 }
 
-void Models::ListModel(const HttpRequestPtr& req,
-                       std::function<void(const HttpResponsePtr&)>&& callback,
-                       std::optional<std::string> author) const {
-  if (author.has_value()) {
-    auto res = model_src_svc_->GetRepositoryList(author.value());
-    if (res.has_error()) {
-      Json::Value ret;
-      ret["message"] = res.error();
-      auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
-      resp->setStatusCode(k400BadRequest);
-      callback(resp);
-    } else {
-      auto& info = res.value();
-      Json::Value ret;
-      Json::Value arr(Json::arrayValue);
-      for (auto const& i : info) {
-        arr.append(i);
-      }
-      ret["data"] = arr;
-      auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
-      resp->setStatusCode(k200OK);
-      callback(resp);
-    }
-    return;
-  }
-
+void Models::ListModel(
+    const HttpRequestPtr& req,
+    std::function<void(const HttpResponsePtr&)>&& callback) const {
   namespace fs = std::filesystem;
   namespace fmu = file_manager_utils;
   Json::Value ret;
@@ -874,6 +851,33 @@ void Models::GetModelSource(
   } else {
     auto& info = res.value();
     auto resp = cortex_utils::CreateCortexHttpJsonResponse(info.ToJson());
+    resp->setStatusCode(k200OK);
+    callback(resp);
+  }
+}
+
+void Models::GetRepositoryList(
+    const HttpRequestPtr& req,
+    std::function<void(const HttpResponsePtr&)>&& callback,
+    std::optional<std::string> author) {
+  if (!author.has_value())
+    author = "cortexso";
+  auto res = model_src_svc_->GetRepositoryList(author.value());
+  if (res.has_error()) {
+    Json::Value ret;
+    ret["message"] = res.error();
+    auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
+    resp->setStatusCode(k400BadRequest);
+    callback(resp);
+  } else {
+    auto& info = res.value();
+    Json::Value ret;
+    Json::Value arr(Json::arrayValue);
+    for (auto const& i : info) {
+      arr.append(i);
+    }
+    ret["data"] = arr;
+    auto resp = cortex_utils::CreateCortexHttpJsonResponse(ret);
     resp->setStatusCode(k200OK);
     callback(resp);
   }

--- a/engine/controllers/models.h
+++ b/engine/controllers/models.h
@@ -30,7 +30,7 @@ class Models : public drogon::HttpController<Models, false> {
 
   ADD_METHOD_TO(Models::PullModel, "/v1/models/pull", Options, Post);
   ADD_METHOD_TO(Models::AbortPullModel, "/v1/models/pull", Options, Delete);
-  ADD_METHOD_TO(Models::ListModel, "/v1/models?author={author}", Get);
+  ADD_METHOD_TO(Models::ListModel, "/v1/models", Get);
   ADD_METHOD_TO(Models::GetModel, "/v1/models/{1}", Get);
   ADD_METHOD_TO(Models::UpdateModel, "/v1/models/{1}", Options, Patch);
   ADD_METHOD_TO(Models::ImportModel, "/v1/models/import", Options, Post);
@@ -44,6 +44,8 @@ class Models : public drogon::HttpController<Models, false> {
   ADD_METHOD_TO(Models::DeleteModelSource, "/v1/models/sources", Delete);
   ADD_METHOD_TO(Models::GetModelSources, "/v1/models/sources", Get);
   ADD_METHOD_TO(Models::GetModelSource, "/v1/models/sources/{src}", Get);
+  ADD_METHOD_TO(Models::GetRepositoryList, "/v1/models/hub?author={author}",
+                Get);
   METHOD_LIST_END
 
   explicit Models(std::shared_ptr<DatabaseService> db_service,
@@ -63,8 +65,7 @@ class Models : public drogon::HttpController<Models, false> {
   void AbortPullModel(const HttpRequestPtr& req,
                       std::function<void(const HttpResponsePtr&)>&& callback);
   void ListModel(const HttpRequestPtr& req,
-                 std::function<void(const HttpResponsePtr&)>&& callback,
-                 std::optional<std::string> author) const;
+                 std::function<void(const HttpResponsePtr&)>&& callback) const;
   void GetModel(const HttpRequestPtr& req,
                 std::function<void(const HttpResponsePtr&)>&& callback,
                 const std::string& model_id) const;
@@ -111,6 +112,10 @@ class Models : public drogon::HttpController<Models, false> {
   void GetModelSource(const HttpRequestPtr& req,
                       std::function<void(const HttpResponsePtr&)>&& callback,
                       const std::string& src);
+
+  void GetRepositoryList(const HttpRequestPtr& req,
+                         std::function<void(const HttpResponsePtr&)>&& callback,
+                         std::optional<std::string> author);
 
  private:
   std::shared_ptr<DatabaseService> db_service_;


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `Models` class in the `engine/controllers/models.cc` and `engine/controllers/models.h` files. The main focus of these changes is to refactor the `ListModel` method and introduce a new `GetRepositoryList` method.

Refactoring and new method introduction:

* [`engine/controllers/models.cc`](diffhunk://#diff-3318b780616ed76cc8983db3e058691572ab10b81522947962d5e107cc171fc8L171-R173): Refactored the `ListModel` method to remove the `author` parameter and its associated logic.
* [`engine/controllers/models.cc`](diffhunk://#diff-3318b780616ed76cc8983db3e058691572ab10b81522947962d5e107cc171fc8R858-R884): Added a new `GetRepositoryList` method to handle repository listing, including optional author parameter handling.

Updates to method declarations in the header file:

* [`engine/controllers/models.h`](diffhunk://#diff-bc964d4fc186e6a59dac85241cdff2572c04815a1e0c5a9e06c1a2d215b39c83L66-R68): Updated the `ListModel` method declaration to match the refactored implementation without the `author` parameter.
* [`engine/controllers/models.h`](diffhunk://#diff-bc964d4fc186e6a59dac85241cdff2572c04815a1e0c5a9e06c1a2d215b39c83R116-R119): Added the new `GetRepositoryList` method declaration.

Routing changes:

* [`engine/controllers/models.h`](diffhunk://#diff-bc964d4fc186e6a59dac85241cdff2572c04815a1e0c5a9e06c1a2d215b39c83L33-R33): Updated the route for `ListModel` to remove the `author` query parameter.
* [`engine/controllers/models.h`](diffhunk://#diff-bc964d4fc186e6a59dac85241cdff2572c04815a1e0c5a9e06c1a2d215b39c83R47-R48): Added a new route for `GetRepositoryList` with an optional `author` query parameter.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed