### PR TITLE
fix: append stop words from request in case of using template renderer for local engine

### DIFF
--- a/engine/services/inference_service.cc
+++ b/engine/services/inference_service.cc
@@ -66,9 +66,21 @@ cpp::result<void, InferResult> InferenceService::HandleChatCompletion(
             tokenizer->add_eos_token, tokenizer->add_generation_prompt);
         if (prompt_result.has_value()) {
           (*json_body)["prompt"] = prompt_result.value();
-          Json::Value stops(Json::arrayValue);
-          stops.append(tokenizer->eos_token);
-          (*json_body)["stop"] = stops;
+          if (json_body->isMember("stop")) {
+            bool need_append = true;
+            for (auto& s : (*json_body)["stop"]) {
+              if (s.asString() == tokenizer->eos_token) {
+                need_append = false;
+              }
+            }
+            if (need_append) {
+              (*json_body)["stop"].append(tokenizer->eos_token);
+            }
+          } else {
+            Json::Value stops(Json::arrayValue);
+            stops.append(tokenizer->eos_token);
+            (*json_body)["stop"] = stops;
+          }
         } else {
           CTL_ERR("Failed to render prompt: " + prompt_result.error());
         }


### PR DESCRIPTION
## Describe Your Changes

This pull request includes an important change to the `InferenceService::HandleChatCompletion` method in the `engine/services/inference_service.cc` file. The change ensures that the end-of-sequence (EOS) token is correctly appended to the `stop` field in the JSON body if it is not already present.

Key change:

* [`engine/services/inference_service.cc`](diffhunk://#diff-e165ef8bee4fa9dfd1a2d044abdc345eb7784ee2708a14cd582cb33ec9beceb0R69-R83): Added logic to check if the `stop` field in the JSON body already contains the EOS token and append it if necessary.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/2016

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed