### PR TITLE
chore: update tests

### DIFF
--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -5356,7 +5356,7 @@
             "type": "string",
             "description": "The identifier or URL of the model to use. It can be a model ID on Cortexso (https://huggingface.co/cortexso) or a HuggingFace URL pointing to the model file. For example: 'gpt2' or 'https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/blob/main/mistral-7b-instruct-v0.1.Q2_K.gguf'",
             "examples": [
-              "tinyllama:gguf",
+              "tinyllama:1b",
               "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/blob/main/mistral-7b-instruct-v0.1.Q2_K.gguf"
             ]
           },

--- a/engine/e2e-test/api/model/test_api_model.py
+++ b/engine/e2e-test/api/model/test_api_model.py
@@ -95,14 +95,14 @@ class TestApiModel:
         time.sleep(30)
 
         print("Pull model")
-        json_body = {"model": "tinyllama:gguf"}
+        json_body = {"model": "tinyllama:1b"}
         response = requests.post("http://localhost:3928/v1/models/pull", json=json_body)
-        assert response.status_code == 200, f"Failed to pull model: tinyllama:gguf"
+        assert response.status_code == 200, f"Failed to pull model: tinyllama:1b"
         await wait_for_websocket_download_success_event(timeout=None)
         
         # get API
         print("Get model")
-        response = requests.get("http://localhost:3928/v1/models/tinyllama:gguf")
+        response = requests.get("http://localhost:3928/v1/models/tinyllama:1b")
         assert response.status_code == 200
         
         # list API
@@ -111,7 +111,7 @@ class TestApiModel:
         assert response.status_code == 200
 
         print("Start model")
-        json_body = {"model": "tinyllama:gguf"}
+        json_body = {"model": "tinyllama:1b"}
         response = requests.post(
             "http://localhost:3928/v1/models/start", json=json_body
         )
@@ -123,13 +123,13 @@ class TestApiModel:
                 
         # update API
         print("Update model")
-        body_json = {'model': 'tinyllama:gguf'}
-        response = requests.patch("http://localhost:3928/v1/models/tinyllama:gguf", json = body_json)        
+        body_json = {'model': 'tinyllama:1b'}
+        response = requests.patch("http://localhost:3928/v1/models/tinyllama:1b", json = body_json)        
         assert response.status_code == 200
 
         # delete API
         print("Delete model")
-        response = requests.delete("http://localhost:3928/v1/models/tinyllama:gguf")
+        response = requests.delete("http://localhost:3928/v1/models/tinyllama:1b")
         assert response.status_code == 200
         
     def test_models_sources_api(self):

--- a/engine/e2e-test/api/model/test_api_model_import.py
+++ b/engine/e2e-test/api/model/test_api_model_import.py
@@ -16,14 +16,14 @@ class TestApiModelImport:
 
     @pytest.mark.skipif(True, reason="Expensive test. Only test when you have local gguf file.")
     def test_model_import_should_be_success(self):
-        body_json = {'model': 'tinyllama:gguf',
+        body_json = {'model': 'tinyllama:1b',
                      'modelPath': '/path/to/local/gguf'}
         response = requests.post("http://localhost:3928/v1/models/import", json=body_json)              
         assert response.status_code == 200
 
     @pytest.mark.skipif(True, reason="Expensive test. Only test when you have local gguf file.")
     def test_model_import_with_name_should_be_success(self):
-        body_json = {'model': 'tinyllama:gguf',
+        body_json = {'model': 'tinyllama:1b',
                      'modelPath': '/path/to/local/gguf',
                      'name': 'test_model'}
         response = requests.post("http://localhost:3928/v1/models/import", json=body_json)
@@ -45,7 +45,7 @@ class TestApiModelImport:
         assert response.json()['files'][0] != '/path/to/local/gguf'
 
     def test_model_import_with_invalid_path_should_fail(self):
-        body_json = {'model': 'tinyllama:gguf',
+        body_json = {'model': 'tinyllama:1b',
                      'modelPath': '/invalid/path/to/gguf'}
         response = requests.post("http://localhost:3928/v1/models/import", json=body_json)
         assert response.status_code == 400

--- a/engine/e2e-test/cli/model/test_cli_model.py
+++ b/engine/e2e-test/cli/model/test_cli_model.py
@@ -22,7 +22,7 @@ class TestCliModel:
 
         # Teardown
         # Clean up
-        run("Delete model", ["models", "delete", "tinyllama:gguf"])
+        run("Delete model", ["models", "delete", "tinyllama:1b"])
         stop_server()
         
     def test_model_pull_with_direct_url_should_be_success(self):
@@ -40,13 +40,13 @@ class TestCliModel:
         
     @pytest.mark.asyncio
     async def test_models_delete_should_be_successful(self):
-        json_body = {"model": "tinyllama:gguf"}
+        json_body = {"model": "tinyllama:1b"}
         response = requests.post("http://localhost:3928/v1/models/pull", json=json_body)
-        assert response.status_code == 200, f"Failed to pull model: tinyllama:gguf"
+        assert response.status_code == 200, f"Failed to pull model: tinyllama:1b"
         await wait_for_websocket_download_success_event(timeout=None)
 
         exit_code, output, error = run(
-            "Delete model", ["models", "delete", "tinyllama:gguf"]
+            "Delete model", ["models", "delete", "tinyllama:1b"]
         )
-        assert "Model tinyllama:gguf deleted successfully" in output
+        assert "Model tinyllama:1b deleted successfully" in output
         assert exit_code == 0, f"Model does not exist: {error}"

--- a/engine/e2e-test/local_test.py
+++ b/engine/e2e-test/local_test.py
@@ -9,7 +9,7 @@ import argparse
 import websockets
 
 # Define a list of request configurations
-model_id = "tinyllama:gguf"
+model_id = "tinyllama:1b"
 
 
 def make_request(config):
@@ -78,7 +78,7 @@ def get_setup_configs(host_port):
             "method": "POST",
             "url": "http://" + host_port + "/v1/models/pull",
             "headers": {"Content-Type": "application/json"},
-            "data": {"model": "tinyllama:gguf"},
+            "data": {"model": "tinyllama:1b"},
         },
         {
             "method": "POST",
@@ -89,14 +89,14 @@ def get_setup_configs(host_port):
             "method": "POST",
             "url": "http://" + host_port + "/v1/models/start",
             "headers": {"Content-Type": "application/json"},
-            "data": {"model": "tinyllama:gguf"},
+            "data": {"model": "tinyllama:1b"},
         },
         {
             "method": "POST",
             "url": "http://" + host_port + "/v1/chat/completions",
             "headers": {"Content-Type": "application/json"},
             "data": {
-                "model": "tinyllama:gguf",
+                "model": "tinyllama:1b",
                 "stream": True,
                 "messages": [{"content": "How are you today?", "role": "user"}],
                 "max_tokens": 256,
@@ -111,7 +111,7 @@ def get_teardown_configs(host_port):
             "method": "POST",
             "url": "http://" + host_port + "/v1/models/stop",
             "headers": {"Content-Type": "application/json"},
-            "data": {"model": "tinyllama:gguf"},
+            "data": {"model": "tinyllama:1b"},
         },
         {
             "method": "DELETE",

--- a/engine/e2e-test/test_api_docker.py
+++ b/engine/e2e-test/test_api_docker.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 from utils.test_runner import wait_for_websocket_download_success_event
 
-repo_branches = ["tinyllama:gguf"]
+repo_branches = ["tinyllama:1b"]
 
 
 class TestCortexsoModels:

--- a/engine/e2e-test/utils/test_runner.py
+++ b/engine/e2e-test/utils/test_runner.py
@@ -90,7 +90,7 @@ def start_server_if_needed():
         start_server()
         
 
-def pull_model_if_needed(model_id: str = "tinyllama:gguf"):
+def pull_model_if_needed(model_id: str = "tinyllama:1b"):
     """
     Pull the model if it is not already pulled.
     """

--- a/engine/test/components/test_event.cc
+++ b/engine/test/components/test_event.cc
@@ -9,7 +9,7 @@ TEST_F(EventTest, EventFromString) {
   // clang-format off
   std::string ev_str = R"({
     "task": {
-      "id": "tinyllama:gguf",
+      "id": "tinyllama:1b",
       "items": [
         {
           "bytes": 668788096,

--- a/engine/test/components/test_huggingface_utils.cc
+++ b/engine/test/components/test_huggingface_utils.cc
@@ -7,17 +7,16 @@ TEST_F(HuggingFaceUtilTestSuite, TestGetModelRepositoryBranches) {
   auto branches =
       huggingface_utils::GetModelRepositoryBranches("cortexso", "tinyllama");
 
-  EXPECT_GE(branches.value().size(), 3);
+  EXPECT_GE(branches.value().size(), 1);
   EXPECT_EQ(branches.value()["main"].name, "main");
   EXPECT_EQ(branches.value()["main"].ref, "refs/heads/main");
   EXPECT_EQ(branches.value()["1b"].name, "1b");
   EXPECT_EQ(branches.value()["1b"].ref, "refs/heads/1b");
-  EXPECT_EQ(branches.value()["gguf"].name, "gguf");
-  EXPECT_EQ(branches.value()["gguf"].ref, "refs/heads/gguf");
 }
 
 // TODO(sang) re-enable when main branch is fixed
-TEST_F(HuggingFaceUtilTestSuite, DISABLED_TestGetHuggingFaceModelRepoInfoSuccessfully) {
+TEST_F(HuggingFaceUtilTestSuite,
+       DISABLED_TestGetHuggingFaceModelRepoInfoSuccessfully) {
   auto model_info =
       huggingface_utils::GetHuggingFaceModelRepoInfo("cortexso", "tinyllama");
 


### PR DESCRIPTION
## Describe Your Changes
This pull request updates various references to the `tinyllama:gguf` model to use the `tinyllama:1b` model instead. The changes span across multiple test files and configurations.

### Model Reference Updates:

* [`docs/static/openapi/cortex.json`](diffhunk://#diff-23810d34abae2c92c32a574ffdeb400923d2e42c2317f7a19b04c51fc5df7e48L5359-R5359): Updated the example model identifier from `tinyllama:gguf` to `tinyllama:1b`.

### Test Files:

* [`engine/e2e-test/api/model/test_api_model.py`](diffhunk://#diff-14ff484d17f685e1e763650aba0ed54c0994f66fa2625d2fcef49e392e0b50ffL98-R105): Replaced all occurrences of `tinyllama:gguf` with `tinyllama:1b` in the `test_models_start_stop_should_be_successful` method. [[1]](diffhunk://#diff-14ff484d17f685e1e763650aba0ed54c0994f66fa2625d2fcef49e392e0b50ffL98-R105) [[2]](diffhunk://#diff-14ff484d17f685e1e763650aba0ed54c0994f66fa2625d2fcef49e392e0b50ffL114-R114) [[3]](diffhunk://#diff-14ff484d17f685e1e763650aba0ed54c0994f66fa2625d2fcef49e392e0b50ffL126-R132)
* [`engine/e2e-test/api/model/test_api_model_import.py`](diffhunk://#diff-df824b538413446115748b4595888b9d68af315366e0311fc4375aeb3e1a63fcL19-R26): Updated the model identifier in multiple test methods to `tinyllama:1b`. [[1]](diffhunk://#diff-df824b538413446115748b4595888b9d68af315366e0311fc4375aeb3e1a63fcL19-R26) [[2]](diffhunk://#diff-df824b538413446115748b4595888b9d68af315366e0311fc4375aeb3e1a63fcL48-R48)
* [`engine/e2e-test/cli/model/test_cli_model.py`](diffhunk://#diff-db7d5889195296980feb4ffef8f8d8a0372f85b1fd3188ef7c5ce7fb9bcd1566L25-R25): Changed the model identifier to `tinyllama:1b` in CLI tests. [[1]](diffhunk://#diff-db7d5889195296980feb4ffef8f8d8a0372f85b1fd3188ef7c5ce7fb9bcd1566L25-R25) [[2]](diffhunk://#diff-db7d5889195296980feb4ffef8f8d8a0372f85b1fd3188ef7c5ce7fb9bcd1566L43-R51)
* [`engine/e2e-test/local_test.py`](diffhunk://#diff-ec8410b54ed506b18d365dfefe31cdcef1aaf8ec211e6c8281006863e05e6474L12-R12): Modified the model identifier to `tinyllama:1b` in setup and teardown configurations. [[1]](diffhunk://#diff-ec8410b54ed506b18d365dfefe31cdcef1aaf8ec211e6c8281006863e05e6474L12-R12) [[2]](diffhunk://#diff-ec8410b54ed506b18d365dfefe31cdcef1aaf8ec211e6c8281006863e05e6474L81-R81) [[3]](diffhunk://#diff-ec8410b54ed506b18d365dfefe31cdcef1aaf8ec211e6c8281006863e05e6474L92-R99) [[4]](diffhunk://#diff-ec8410b54ed506b18d365dfefe31cdcef1aaf8ec211e6c8281006863e05e6474L114-R114)
* [`engine/e2e-test/test_api_docker.py`](diffhunk://#diff-f5d4da480e62d5abc1921045d45792e735673fa8845d1ef9cbe9c264ebd093b6L5-R5): Updated the `repo_branches` list to include `tinyllama:1b` instead of `tinyllama:gguf`.
* [`engine/e2e-test/utils/test_runner.py`](diffhunk://#diff-889d162f54596a726916825367ac546dd34bc24b3e99e6dd38d57b58fad5c176L93-R93): Changed the default model ID in the `pull_model_if_needed` function to `tinyllama:1b`.

### C++ Test Files:

* [`engine/test/components/test_event.cc`](diffhunk://#diff-762ae8eb437d07a47c76c7b0a98aa4f99dcdb30b586cf4846452cc15e475b50aL12-R12): Updated the model ID in the `EventFromString` test to `tinyllama:1b`.
* [`engine/test/components/test_huggingface_utils.cc`](diffhunk://#diff-b7c3bbcd53a56da00a9f03e7fe53be3327ac1fe3720e63e18a468ae7727d805aL10-R19): Modified the expected branches in the `TestGetModelRepositoryBranches` test to reflect the new model identifier `tinyllama:1b`.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed