### PR TITLE
fix: default GPUs setting

### DIFF
--- a/engine/common/hardware_common.h
+++ b/engine/common/hardware_common.h
@@ -69,6 +69,16 @@ struct NvidiaAddInfo {
 };
 struct AmdAddInfo {};
 using GPUAddInfo = std::variant<NvidiaAddInfo, AmdAddInfo>;
+
+enum class GpuType {
+  kGpuTypeOther = 0,
+  kGpuTypeIntegrated = 1,
+  kGpuTypeDiscrete = 2,
+  kGpuTypeVirtual = 3,
+  kGpuTypeCpu = 4,
+  kGpuTypeMaxEnum = 0x7FFFFFFF
+};
+
 struct GPU {
   std::string id;
   uint32_t device_id;
@@ -80,6 +90,7 @@ struct GPU {
   std::string uuid;
   bool is_activated = true;
   std::string vendor;
+  GpuType gpu_type;
 };
 
 inline Json::Value ToJson(const std::vector<GPU>& gpus) {

--- a/engine/services/hardware_service.cc
+++ b/engine/services/hardware_service.cc
@@ -322,23 +322,39 @@ void HardwareService::UpdateHardwareInfos() {
     }
   }
   CTL_INF("Activated GPUs before: " << debug_b);
+  auto has_nvidia = [&gpus] {
+    for (auto const& g : gpus) {
+      if (g.vendor == cortex::hw::kNvidiaStr) {
+        return true;
+      }
+    }
+    return false;
+  }();
+
   for (auto const& gpu : gpus) {
-    // ignore error
-    // Note: only support NVIDIA for now, so hardware_id = software_id
     if (db_service_->HasHardwareEntry(gpu.uuid)) {
       auto res = db_service_->UpdateHardwareEntry(gpu.uuid, std::stoi(gpu.id),
-                                           std::stoi(gpu.id));
+                                                  std::stoi(gpu.id));
       if (res.has_error()) {
         CTL_WRN(res.error());
       }
     } else {
-      auto res =
-      db_service_->AddHardwareEntry(HwEntry{.uuid = gpu.uuid,
-                                         .type = "gpu",
-                                         .hardware_id = std::stoi(gpu.id),
-                                         .software_id = std::stoi(gpu.id),
-                                         .activated = true,
-                                         .priority = INT_MAX});
+      // iGPU should be deactivated by default
+      // Only activate Nvidia GPUs if both AMD and Nvidia GPUs exists
+      auto activated = [&gpu, &gpus, has_nvidia] {
+        if (gpu.gpu_type != cortex::hw::GpuType::kGpuTypeDiscrete)
+          return false;
+        if (has_nvidia && gpu.vendor != cortex::hw::kNvidiaStr)
+          return false;
+        return true;
+      };
+      auto res = db_service_->AddHardwareEntry(
+          HwEntry{.uuid = gpu.uuid,
+                  .type = "gpu",
+                  .hardware_id = std::stoi(gpu.id),
+                  .software_id = std::stoi(gpu.id),
+                  .activated = activated(),
+                  .priority = INT_MAX});
       if (res.has_error()) {
         CTL_WRN(res.error());
       }

--- a/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
+++ b/engine/utils/hardware/gpu/vulkan/vulkan_gpu.h
@@ -24,21 +24,26 @@
 #endif
 
 namespace cortex::hw {
-constexpr const uint32_t NVIDIA_VENDOR = 0x10DE;
-constexpr const uint32_t AMD_VENDOR = 0x1002;
-constexpr const uint32_t INTEL_VENDOR = 0x8086;
-constexpr const uint32_t ARM_VENDOR = 0x13B5;
+constexpr const uint32_t kNvidiaVendor = 0x10DE;
+constexpr const uint32_t kAmdVendor = 0x1002;
+constexpr const uint32_t kIntelVendor = 0x8086;
+constexpr const uint32_t kArmVendor = 0x13B5;
+
+constexpr const auto kAmdStr = "AMD";
+constexpr const auto kNvidiaStr = "NVIDIA";
+constexpr const auto kIntelStr = "INTEL";
+constexpr const auto kArmStr = "ARM";
 
 inline std::string GetVendorStr(uint32_t vendor_id) {
   switch (vendor_id) {
-    case AMD_VENDOR:
-      return "AMD";
-    case NVIDIA_VENDOR:
-      return "NVIDIA";
-    case INTEL_VENDOR:
-      return "INTEL";
-    case ARM_VENDOR:
-      return "ARM";
+    case kAmdVendor:
+      return kAmdStr;
+    case kNvidiaVendor:
+      return kNvidiaStr;
+    case kIntelVendor:
+      return kIntelStr;
+    case kArmVendor:
+      return kArmStr;
     default:
       return std::to_string(vendor_id);
   }
@@ -446,8 +451,8 @@ class VulkanGpu {
 #endif
       int free_vram_MiB =
           total_vram_MiB > used_vram_MiB ? total_vram_MiB - used_vram_MiB : 0;
-      if (device_properties.vendorID == NVIDIA_VENDOR ||
-          device_properties.vendorID == AMD_VENDOR) {
+      if (device_properties.vendorID == kNvidiaVendor ||
+          device_properties.vendorID == kAmdVendor) {
         gpus.emplace_back(cortex::hw::GPU{
             .id = std::to_string(id),
             .device_id = device_properties.deviceID,
@@ -457,7 +462,8 @@ class VulkanGpu {
             .free_vram = free_vram_MiB,
             .total_vram = total_vram_MiB,
             .uuid = uuid_to_string(device_id_properties.deviceUUID),
-            .vendor = GetVendorStr(device_properties.vendorID)});
+            .vendor = GetVendorStr(device_properties.vendorID),
+            .gpu_type = static_cast<GpuType>(device_properties.deviceType)});
       }
       id++;
     }

--- a/engine/utils/hardware/gpu_info.h
+++ b/engine/utils/hardware/gpu_info.h
@@ -25,7 +25,7 @@ inline std::vector<GPU> GetGPUInfo() {
             .compute_cap = nvidia_gpus[i].compute_cap.value_or("unknown")};
         vulkan_gpus[j].free_vram = std::stoll(nvidia_gpus[i].vram_free);
         vulkan_gpus[j].total_vram = std::stoll(nvidia_gpus[i].vram_total);
-        vulkan_gpus[j].vendor = nvidia_gpus[i].vendor;
+        vulkan_gpus[j].vendor = nvidia_gpus[i].vendor;        
       }
     }
   }
@@ -55,7 +55,8 @@ inline std::vector<GPU> GetGPUInfo() {
               .free_vram = std::stoi(n.vram_free),
               .total_vram = std::stoi(n.vram_total),
               .uuid = n.uuid,
-              .vendor = n.vendor});
+              .vendor = n.vendor,
+              .gpu_type = GpuType::kGpuTypeDiscrete});
     }
     return res;
   }


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces several changes to enhance GPU handling in the codebase, including the addition of a `GpuType` enum, updates to the `GPU` struct, and improvements in GPU activation logic. The most important changes are summarized below:

### Enhancements to GPU Handling:

* Added `GpuType` enum to classify different types of GPUs (`kGpuTypeOther`, `kGpuTypeIntegrated`, `kGpuTypeDiscrete`, `kGpuTypeVirtual`, `kGpuTypeCpu`, `kGpuTypeMaxEnum`). (`[engine/common/hardware_common.hR72-R81](diffhunk://#diff-adc20b97e31aa35d61ede3a2523f0126b79c4f0a2008165890d01e5ba9a6f335R72-R81)`)

* Updated `GPU` struct to include a new `gpu_type` field for storing the type of GPU. (`[engine/common/hardware_common.hR93](diffhunk://#diff-adc20b97e31aa35d61ede3a2523f0126b79c4f0a2008165890d01e5ba9a6f335R93)`)

### Improvements in GPU Activation Logic:

* Modified `HardwareService::UpdateHardwareInfos` to deactivate integrated GPUs by default and only activate Nvidia GPUs if both AMD and Nvidia GPUs are present. (`[engine/services/hardware_service.ccL326-R354](diffhunk://#diff-6c5bdad74c539cf749ffac42cc1728ea62c51388ece867102fd2ce2e4fd1c956L326-R354)`)

### Vendor Constants and GPU Type Integration:

* Changed vendor constants to use a consistent naming convention (`kNvidiaVendor`, `kAmdVendor`, `kIntelVendor`, `kArmVendor`) and added corresponding string constants (`kAmdStr`, `kNvidiaStr`, `kIntelStr`, `kArmStr`). (`[engine/utils/hardware/gpu/vulkan/vulkan_gpu.hL27-R46](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L27-R46)`)

* Updated `VulkanGpu` class to use the new vendor constants and set the `gpu_type` field based on the device type. (`[[1]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L449-R455)`, `[[2]](diffhunk://#diff-4d54c52435d403a598d3f7cf4b82bbc50ec768d7ccde9d107a552fe4faa2e385L460-R466)`)

* Updated `GetGPUInfo` function to set the `gpu_type` field to `GpuType::kGpuTypeDiscrete` for all GPUs. (`[engine/utils/hardware/gpu_info.hL58-R59](diffhunk://#diff-9c36f24988079b524e8b6e58945df24ca2ce26a3f02d95fa4c43a3fa9ef64413L58-R59)`)

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/2018

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed