### PR TITLE
Enhancement: Use XDG Directory Specification by default on Linux

### DIFF
--- a/engine/e2e-test/cli/common/test_create_log_folder.py
+++ b/engine/e2e-test/cli/common/test_create_log_folder.py
@@ -6,12 +6,21 @@ from utils.test_runner import run
 from utils.test_runner import start_server, stop_server
 
 
+def get_root_path():
+    if platform.system() == "Linux":
+        # For Linux, use the XDG base directory.
+        # Here we use XDG_DATA_HOME if set, otherwise default to ~/.local/share.
+        return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    else:
+        return Path.home()
+
+
 class TestCreateLogFolder:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         # Setup
         stop_server()
-        root = Path.home()
+        root = get_root_path()
         if os.path.exists(root / "cortexcpp" / "logs"):
             shutil.rmtree(root / "cortexcpp" / "logs")
         success = start_server()
@@ -24,7 +33,7 @@ class TestCreateLogFolder:
         stop_server()
 
     def test_create_log_folder_run_successfully(self):
-        root = Path.home()
+        root = get_root_path()
         assert (
             os.path.exists(root / "cortexcpp" / "logs")
             or os.path.exists(root / "cortexcpp-beta" / "logs")

--- a/engine/e2e-test/cli/common/test_create_log_folder.py
+++ b/engine/e2e-test/cli/common/test_create_log_folder.py
@@ -14,7 +14,6 @@ def get_root_path():
     else:
         return Path.home()
 
-
 class TestCreateLogFolder:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):

--- a/engine/utils/file_manager_utils.cc
+++ b/engine/utils/file_manager_utils.cc
@@ -79,7 +79,7 @@ std::filesystem::path GetHomeDirectoryPath() {
 }
 
 // Helper function to get XDG base directory, falling back to default if not set
-std::filesystem::path GetXDGDirectory(const std::string& envVar,
+std::filesystem::path GetXDGDirectoryPath(const std::string& envVar,
                                       const std::string& defaultPath) {
   if (const char* envValue = std::getenv(envVar.c_str());
       envValue && std::strlen(envValue) > 0) {
@@ -125,7 +125,7 @@ std::filesystem::path GetConfigurationPath() {
   // CTL_INF("Config file name: " + config_file_name);
 #if defined(__linux__)
   auto config_base_path =
-      GetXDGDirectory("XDG_CONFIG_HOME", ".config") / kCortexFolderName;
+      GetXDGDirectoryPath("XDG_CONFIG_HOME", ".config") / kCortexFolderName;
   auto configuration_path = config_base_path / config_file_name;
 #else
   auto home_path = GetHomeDirectoryPath();
@@ -168,7 +168,7 @@ config_yaml_utils::CortexConfig GetDefaultConfig() {
 #if defined(__linux__)
   auto default_data_folder_path =
       cortex_data_folder_path.empty()
-          ? file_manager_utils::GetXDGDirectory("XDG_DATA_HOME",
+          ? file_manager_utils::GetXDGDirectoryPath("XDG_DATA_HOME",
                                                 ".local/share") /
                 default_data_folder_name
           : std::filesystem::path(cortex_data_folder_path);
@@ -265,7 +265,7 @@ std::filesystem::path GetCortexDataPath() {
 #endif
   } else {
 #if defined(__linux__)
-    auto data_base_path = GetXDGDirectory("XDG_DATA_HOME", ".local/share");
+    auto data_base_path = GetXDGDirectoryPath("XDG_DATA_HOME", ".local/share");
     data_folder_path = data_base_path / GetDefaultDataFolderName();
 #else
     auto home_path = GetHomeDirectoryPath();
@@ -293,7 +293,7 @@ std::filesystem::path GetCortexLogPath() {
     log_folder_path = std::filesystem::path(config.logFolderPath);
   } else {
 #if defined(__linux__)
-    auto data_base_path = GetXDGDirectory("XDG_DATA_HOME", ".local/share");
+    auto data_base_path = GetXDGDirectoryPath("XDG_DATA_HOME", ".local/share");
     log_folder_path = data_base_path / GetDefaultDataFolderName() / "logs";
 #else
     auto home_path = GetHomeDirectoryPath();

--- a/engine/utils/file_manager_utils.cc
+++ b/engine/utils/file_manager_utils.cc
@@ -127,11 +127,6 @@ std::filesystem::path GetConfigurationPath() {
   auto config_base_path =
       GetXDGDirectory("XDG_CONFIG_HOME", ".config") / kCortexFolderName;
   auto configuration_path = config_base_path / config_file_name;
-  if (!std::filesystem::exists(config_base_path)) {
-    CTL_INF("Cortex config folder not found. Create one: " +
-            config_base_path.string());
-    std::filesystem::create_directory(config_base_path);
-  }
 #else
   auto home_path = GetHomeDirectoryPath();
   auto configuration_path = home_path / config_file_name;
@@ -232,6 +227,10 @@ cpp::result<void, std::string> CreateConfigFileIfNotExist() {
   if (std::filesystem::exists(config_path)) {
     // already exists, no need to create
     return {};
+  }
+  if (!std::filesystem::exists(config_path.parent_path())) {
+    // Ensure the configuration directory exists
+    std::filesystem::create_directories(config_path.parent_path());
   }
 
   CLI_LOG("Config file not found. Creating one at " + config_path.string());


### PR DESCRIPTION
## Describe Your Changes 

This PR updates file path handling on Linux to follow the XDG Base Directory Specification, ensuring better organization and adherence to standard Linux conventions.  

#### **Changes**  
- Introduced `GetXDGDirectoryPath()` to retrieve XDG-compliant paths with proper fallbacks.  
- Updated:  
  - `GetConfigurationPath()`, `GetDefaultConfig()`,
`CreateConfigIfNotExist()`,
 `GetCortexDataPath()`, and `GetCortexLogPath()` to use `XDG_CONFIG_HOME` and `XDG_DATA_HOME` instead of defaulting to `$HOME` on Linux.  
- Ensured missing directories are created when necessary.  

#### **Impact**  
- **Linux Users**: Configuration, data, and logs now follow XDG standards.  
- **Improved Maintainability**: Cleaner and safer path handling.  


## Fixes Issues

- Closes #2004


## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

Tested locally by running cortex, downloading a model from cortexso running it as cli.
This might cause some breaking changes. Need to test it more before merging to ensure no regressions.