### PR TITLE
fix: skip main branch for cortexso model source if has metadata.yml

### DIFF
--- a/engine/utils/huggingface_utils.h
+++ b/engine/utils/huggingface_utils.h
@@ -312,13 +312,13 @@ inline std::optional<std::string> GetDefaultBranch(
   }
 }
 
-inline std::optional<std::string> GetModelAuthorCortexsoHub(
+inline cpp::result<std::string, std::string> GetModelAuthorCortexsoHub(
     const std::string& model_name) {
   try {
     auto remote_yml = curl_utils::ReadRemoteYaml(GetMetadataUrl(model_name));
 
     if (remote_yml.has_error()) {
-      return std::nullopt;
+      return cpp::fail(remote_yml.error());
     }
 
     auto metadata = remote_yml.value();
@@ -326,9 +326,9 @@ inline std::optional<std::string> GetModelAuthorCortexsoHub(
     if (author.IsDefined()) {
       return author.as<std::string>();
     }
-    return std::nullopt;
+    return "";
   } catch (const std::exception& e) {
-    return std::nullopt;
+    return "";
   }
 }
 }  // namespace huggingface_utils


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `ModelSourceService` and `huggingface_utils` files to improve error handling and streamline the process of skipping certain branches. The most important changes are listed below:

### Error Handling Improvements:

* [`engine/utils/huggingface_utils.h`](diffhunk://#diff-dfd7b3d4ce2f0ef40f47f154b840baf03ba44ca72adfaf1200e47392815c362cL315-R331): Changed the return type of `GetModelAuthorCortexsoHub` from `std::optional<std::string>` to `cpp::result<std::string, std::string>` to better handle errors and provide more informative error messages.

### Code Simplification:

* [`engine/services/model_source_service.cc`](diffhunk://#diff-225d6c36ec6eb8d79e9a7c17c22cba8a3b9bde1cff73f1e46a363ab444a3a134R435-R438): Updated the `AddCortexsoRepo` method to use the new `cpp::result` return type for `GetModelAuthorCortexsoHub`, ensuring that the author is correctly assigned and errors are handled properly.
* [`engine/services/model_source_service.cc`](diffhunk://#diff-225d6c36ec6eb8d79e9a7c17c22cba8a3b9bde1cff73f1e46a363ab444a3a134R447-R450): Added a check to skip the "main" branch if there are no errors with the model author, reducing unnecessary processing.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed