### PR TITLE
fix: context length for model import

### DIFF
--- a/engine/config/gguf_parser.cc
+++ b/engine/config/gguf_parser.cc
@@ -2,12 +2,12 @@
 #include <cstdint>
 #include <cstring>
 #include <ctime>
+#include <filesystem>
 #include <iostream>
 #include <regex>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <filesystem>
 
 #ifdef _WIN32
 #include <io.h>
@@ -70,7 +70,7 @@ void GGUFHandler::OpenFile(const std::string& file_path) {
 
 #else
   file_size_ = std::filesystem::file_size(file_path);
- 
+
   int file_descriptor = open(file_path.c_str(), O_RDONLY);
   // Memory-map the file
   data_ = static_cast<uint8_t*>(
@@ -105,7 +105,8 @@ std::pair<std::size_t, std::string> GGUFHandler::ReadString(
   std::memcpy(&length, data_ + offset, sizeof(uint64_t));
 
   if (offset + 8 + length > file_size_) {
-    throw std::runtime_error("GGUF metadata string length exceeds file size.\n");
+    throw std::runtime_error(
+        "GGUF metadata string length exceeds file size.\n");
   }
 
   std::string value(reinterpret_cast<const char*>(data_ + offset + 8), length);
@@ -578,9 +579,8 @@ void GGUFHandler::ModelConfigFromMetadata() {
   model_config_.model = name;
   model_config_.id = name;
   model_config_.version = std::to_string(version);
-  model_config_.max_tokens =
-      std::min<int>(kDefaultMaxContextLength, max_tokens);
-  model_config_.ctx_len = std::min<int>(kDefaultMaxContextLength, max_tokens);
+  model_config_.max_tokens = max_tokens;
+  model_config_.ctx_len = max_tokens;
   model_config_.ngl = ngl;
 }
 

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -954,6 +954,7 @@ cpp::result<StartModelResult, std::string> ModelService::StartModel(
       json_data["user_prompt"] = mc.user_template;
       json_data["ai_prompt"] = mc.ai_template;
       json_data["ctx_len"] = std::min(kDefautlContextLength, mc.ctx_len);
+      json_data["max_tokens"] = std::min(kDefautlContextLength, mc.ctx_len);
       max_model_context_length = mc.ctx_len;
     } else {
       bypass_stop_check_set_.insert(model_handle);
@@ -977,6 +978,8 @@ cpp::result<StartModelResult, std::string> ModelService::StartModel(
     // Set the latest ctx_len
     if (ctx_len) {
       json_data["ctx_len"] =
+          std::min(ctx_len.value(), max_model_context_length);
+      json_data["max_tokens"] =
           std::min(ctx_len.value(), max_model_context_length);
     }
     CTL_INF(json_data.toStyledString());


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to the `engine/config/gguf_parser.cc` and `engine/services/model_service.cc` files to improve the handling of model configuration and metadata. The most important changes are grouped by theme below:

### Code Simplification and Cleanup:

* Moved the `#include <filesystem>` directive to the correct position in `engine/config/gguf_parser.cc` to maintain proper alphabetical order of includes.

### Error Handling:

* Reformatted the error message in the `ReadString` method to improve readability.

### Model Configuration:

* Simplified the assignment of `max_tokens` and `ctx_len` in the `ModelConfigFromMetadata` method to directly use `max_tokens` instead of applying a minimum function.
* Added the assignment of `max_tokens` to the JSON data in the `StartModel` method to ensure it is included in the model configuration. [[1]](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefR957) [[2]](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefR982-R983)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed