### PR TITLE
chore: remove unused header

### DIFF
--- a/engine/utils/hardware/gguf/ggml.h
+++ b/engine/utils/hardware/gguf/ggml.h
@@ -2,7 +2,6 @@
 #include <stdint.h>
 #include <string>
 #include <unordered_map>
-#include <vector>
 #include "utils/result.hpp"
 
 namespace hardware {


### PR DESCRIPTION
## Describe Your Changes
- This removes the header <vector> that is not used in the translation unit which increases compilation speed

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed