### PR TITLE
fix: Add missing yaml header

### DIFF
--- a/engine/utils/huggingface_utils.h
+++ b/engine/utils/huggingface_utils.h
@@ -9,6 +9,7 @@
 #include "utils/json_parser_utils.h"
 #include "utils/result.hpp"
 #include "utils/url_parser.h"
+#include "yaml-cpp/yaml.h"
 
 namespace huggingface_utils {
 


### PR DESCRIPTION
## Describe Your Changes

- Add missing `yaml-cpp/yaml.h` header to get definition for `YAML::Node::IsDefined()`

On my Windows VM, it fails to build without that header

```
model_source_service.obj : error LNK2019: unresolved external symbol "public: bool __cdecl YA
ML::Node::IsDefined(void)const " (?IsDefined@Node@YAML@@QEBA_NXZ) referenced in function "cla
ss std::optional<class std::basic_string<char,struct std::char_traits<char>,class std::alloca
tor<char> > > __cdecl huggingface_utils::GetModelAuthorCortexsoHub(class std::basic_string<ch
ar,struct std::char_traits<char>,class std::allocator<char> > const &)" (?GetModelAuthorCorte
xsoHub@huggingface_utils@@YA?AV?$optional@V?$basic_string@DU?$char_traits@D@std@@V?$allocator
@D@2@@std@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@@Z) [C:\Users\
menlo\cortex.cpp\engine\build\cortex-server.vcxproj]
C:\Users\menlo\cortex.cpp\engine\build\cortex-server.exe : fatal error LNK1120: 1 unresolved
externals [C:\Users\menlo\cortex.cpp\engine\build\cortex-server.vcxproj]
```

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed