### PR TITLE
fix: filter out imported models for model sources

### DIFF
--- a/engine/database/models.cc
+++ b/engine/database/models.cc
@@ -310,7 +310,8 @@ cpp::result<std::vector<ModelEntry>, std::string> Models::GetModelSources()
         "SELECT model_id, author_repo_id, branch_name, "
         "path_to_model_yaml, model_alias, model_format, "
         "model_source, status, engine, metadata FROM models "
-        "WHERE model_source != \"\" AND (status = \"downloaded\" OR status = "
+        "WHERE model_source != \"\" AND model_source != \"imported\" AND "
+        "(status = \"downloaded\" OR status = "
         "\"downloadable\")");
     while (query.executeStep()) {
       ModelEntry entry;

--- a/engine/extensions/remote-engine/remote_engine.h
+++ b/engine/extensions/remote-engine/remote_engine.h
@@ -27,6 +27,7 @@ struct StreamContext {
   bool need_stop = true;
   std::string last_request;
   std::string chunks;
+  CURL* curl;
 };
 struct CurlResponse {
   std::string body;

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -155,7 +155,7 @@ ModelService::ModelService(std::shared_ptr<DatabaseService> db_service,
       inference_svc_(inference_service),
       engine_svc_(engine_svc),
       task_queue_(task_queue) {
-  ProcessBgrTasks();
+  // ProcessBgrTasks();
 };
 
 void ModelService::ForceIndexingModelList() {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a few important changes to the `engine/database/models.cc` and `engine/services/model_service.cc` files. The changes primarily focus on refining the model source filtering and modifying background task processing.

Refinements and modifications:

* [`engine/database/models.cc`](diffhunk://#diff-583e4ea9a4c777823e3fd8dcffa570e7762a4cd9368850a8eeb74e53ab83a896L313-R314): Updated the `GetModelSources` method to exclude models with the source labeled as "imported" from the query results.
* [`engine/services/model_service.cc`](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefL158-R158): Commented out the `ProcessBgrTasks` call in the `ModelService` constructor to prevent background tasks from being processed during initialization.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed