### PR TITLE
Add a timeout and disable compression to prevent libcurl OOM errors

### DIFF
--- a/engine/services/download_service.cc
+++ b/engine/services/download_service.cc
@@ -239,6 +239,10 @@ cpp::result<bool, std::string> DownloadService::Download(
   }
 
   SetUpProxy(curl, config_service_);
+	// Disable compression
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+	// Set a connection timeout to 30 seconds
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteCallback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, file);
   if (show_progress) {

--- a/engine/utils/curl_utils.cc
+++ b/engine/utils/curl_utils.cc
@@ -216,6 +216,8 @@ cpp::result<std::string, std::string> SimpleRequest(
 
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body.length());
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
 
   // Perform the request
   auto res = curl_easy_perform(curl);


### PR DESCRIPTION
## Describe Your Changes
While downloading stuff though cortex, libcurl was running OOM, so disabled compression and added a timeout to try to prevent such errors

edit: I will fix the formatting later.