### PR TITLE
fix: initialize SSL

### DIFF
--- a/engine/cli/main.cc
+++ b/engine/cli/main.cc
@@ -1,6 +1,7 @@
 #include <memory>
 #include "command_line_parser.h"
 #include "commands/cortex_upd_cmd.h"
+#include "openssl/ssl.h"
 #include "services/download_service.h"
 #include "utils/archive_utils.h"
 #include "utils/cortex_utils.h"
@@ -88,6 +89,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+  SSL_library_init();
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   bool should_install_server = false;

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -17,6 +17,7 @@
 #include "controllers/threads.h"
 #include "database/database.h"
 #include "migrations/migration_manager.h"
+#include "openssl/ssl.h"
 #include "repositories/assistant_fs_repository.h"
 #include "repositories/file_fs_repository.h"
 #include "repositories/message_fs_repository.h"
@@ -348,6 +349,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+  SSL_library_init();
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   // avoid printing logs to terminal


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces the initialization of the OpenSSL library in the main functions of the `engine/cli` and `engine` components. The most important changes include adding the necessary OpenSSL headers and calling the `SSL_library_init` function.

Initialization of OpenSSL library:

* [`engine/cli/main.cc`](diffhunk://#diff-69189fe282c067a6b1a37de6c868341545e182a051001a476868962b6f732773R4): Added `#include <openssl/ssl.h>` and initialized the OpenSSL library by calling `SSL_library_init()` in the `main` function. [[1]](diffhunk://#diff-69189fe282c067a6b1a37de6c868341545e182a051001a476868962b6f732773R4) [[2]](diffhunk://#diff-69189fe282c067a6b1a37de6c868341545e182a051001a476868962b6f732773R92)
* [`engine/main.cc`](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R20): Added `#include <openssl/ssl.h>` and initialized the OpenSSL library by calling `SSL_library_init()` in the `main` function. [[1]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R20) [[2]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R352)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed