### PR TITLE
feat: support pull and load vision model

### DIFF
--- a/engine/config/model_config.h
+++ b/engine/config/model_config.h
@@ -135,6 +135,7 @@ struct ModelConfig {
   bool text_model = std::numeric_limits<bool>::quiet_NaN();
   std::string id;
   std::vector<std::string> files;
+  std::string mmproj;
   std::size_t created;
   std::string object;
   std::string owned_by = "";
@@ -338,6 +339,9 @@ struct ModelConfig {
       files_array.append(file);
     }
     obj["files"] = files_array;
+    if (!mmproj.empty()) {
+      obj["mmproj"] = mmproj;
+    }
 
     obj["created"] = static_cast<Json::UInt64>(created);
     obj["object"] = object;

--- a/engine/controllers/models.cc
+++ b/engine/controllers/models.cc
@@ -533,8 +533,8 @@ void Models::StartModel(
   auto model_handle = (*(req->getJsonObject())).get("model", "").asString();
 
   std::optional<std::string> mmproj;
-  if (auto& o = (*(req->getJsonObject()))["mmproj"]; !o.isNull()) {
-    mmproj = o.asString();
+  if (auto& o = (*(req->getJsonObject())); o.isMember("mmproj")) {
+    mmproj = o["mmproj"].asString();
   }
 
   auto bypass_llama_model_path = false;

--- a/engine/services/hardware_service.cc
+++ b/engine/services/hardware_service.cc
@@ -304,7 +304,7 @@ void HardwareService::UpdateHardwareInfos() {
   };
   for (auto const& he : b.value()) {
     if (!exists(he.uuid)) {
-      db_service_->DeleteHardwareEntry(he.uuid);
+      (void)db_service_->DeleteHardwareEntry(he.uuid);
     }
   }
 

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -155,8 +155,8 @@ ModelService::ModelService(std::shared_ptr<DatabaseService> db_service,
       inference_svc_(inference_service),
       engine_svc_(engine_svc),
       task_queue_(task_queue) {
-  // ProcessBgrTasks();
-};
+        // ProcessBgrTasks();
+      };
 
 void ModelService::ForceIndexingModelList() {
   CTL_INF("Force indexing model list");
@@ -1005,16 +1005,18 @@ cpp::result<StartModelResult, std::string> ModelService::StartModel(
     auto data = std::get<1>(ir);
 
     if (status == drogon::k200OK) {
-      // start model successfully, we store the metadata so we can use
+      // start model successfully, in case not vision model, we store the metadata so we can use
       // for each inference
-      auto metadata_res = GetModelMetadata(model_handle);
-      if (metadata_res.has_value()) {
-        loaded_model_metadata_map_.emplace(model_handle,
-                                           std::move(metadata_res.value()));
-        CTL_INF("Successfully stored metadata for model " << model_handle);
-      } else {
-        CTL_WRN("Failed to get metadata for model " << model_handle << ": "
-                                                    << metadata_res.error());
+      if (!json_data.isMember("mmproj") || json_data["mmproj"].isNull()) {
+        auto metadata_res = GetModelMetadata(model_handle);
+        if (metadata_res.has_value()) {
+          loaded_model_metadata_map_.emplace(model_handle,
+                                             std::move(metadata_res.value()));
+          CTL_INF("Successfully stored metadata for model " << model_handle);
+        } else {
+          CTL_WRN("Failed to get metadata for model " << model_handle << ": "
+                                                      << metadata_res.error());
+        }
       }
 
       return StartModelResult{.success = true,

--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -947,6 +947,15 @@ cpp::result<StartModelResult, std::string> ModelService::StartModel(
         LOG_WARN << "model_path is empty";
         return StartModelResult{.success = false};
       }
+      if (!mc.mmproj.empty()) {
+#if defined(_WIN32)
+        json_data["mmproj"] = cortex::wc::WstringToUtf8(
+            fmu::ToAbsoluteCortexDataPath(fs::path(mc.mmproj)).wstring());
+#else
+        json_data["mmproj"] =
+            fmu::ToAbsoluteCortexDataPath(fs::path(mc.mmproj)).string();
+#endif
+      }
       json_data["system_prompt"] = mc.system_template;
       json_data["user_prompt"] = mc.user_template;
       json_data["ai_prompt"] = mc.ai_template;


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces several updates to the handling of model configurations, particularly around the inclusion of a new `mmproj` field. The changes span multiple files and primarily focus on ensuring that the `mmproj` field is appropriately read, stored, and written in the configuration process.

Key changes include:

### Model Configuration Updates:
* Added a new `mmproj` field to the `ModelConfig` structure and ensured it is included when converting to and from JSON. (`engine/config/model_config.h` - [[1]](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR158) [[2]](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdR362-R364)
* Updated the `RemoteModelConfig` structure to ensure consistent formatting. (`engine/config/model_config.h` - [engine/config/model_config.hL38-R38](diffhunk://#diff-2fde02d44d8b1ac82ea8adde34594fe6a4f40478472a79825fe82ff883a3b8bdL38-R38))

### YAML Handling Enhancements:
* Modified `YamlHandler::ReadYamlFile` to add the `mmproj` file to the YAML configuration if it exists. (`engine/config/yaml_config.cc` - [engine/config/yaml_config.ccR44-R57](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R44-R57))
* Updated `YamlHandler::ModelConfigFromYaml` to read the `mmproj` field from the YAML configuration. (`engine/config/yaml_config.cc` - [engine/config/yaml_config.ccR148-R149](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R148-R149))
* Enhanced `YamlHandler::UpdateModelConfig` and `YamlHandler::WriteYamlFile` to handle the `mmproj` field. (`engine/config/yaml_config.cc` - [[1]](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R258-R260) [[2]](diffhunk://#diff-0501d8d9d6c0bd6ea4ef6d5448e01edc4b4eee52cfc8364cca3fb04063a58be7R335-R337)

### Model Service and Controller Adjustments:
* Adjusted the `Models::StartModel` method to correctly check for the presence of the `mmproj` field. (`engine/controllers/models.cc` - [engine/controllers/models.ccL536-R537](diffhunk://#diff-3318b780616ed76cc8983db3e058691572ab10b81522947962d5e107cc171fc8L536-R537))
* Updated `ModelService::StartModel` to include the `mmproj` field in the JSON data if it is not empty. (`engine/services/model_service.cc` - [engine/services/model_service.ccR953-R961](diffhunk://#diff-4308355d38ee57a6d711ab65e16bf445b511debcb0b2831d66de1aa52de6deefR953-R961))

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/2048

## Self Checklist

- [x] API: pull vision models, completion request via `/v1/chat/completions`