### PR TITLE
fix: ignored-attributes warning in CommandExecutor

### DIFF
--- a/engine/utils/command_executor.h
+++ b/engine/utils/command_executor.h
@@ -20,7 +20,7 @@ class CommandExecutor {
     if (!pipe) {
       throw std::runtime_error("popen() failed!");
     }
-    m_pipe = std::unique_ptr<FILE, decltype(&PCLOSE)>(pipe, PCLOSE);
+    m_pipe = std::unique_ptr<FILE, int (*)(FILE*)>(pipe, PCLOSE);
   }
 
   CommandExecutor(const CommandExecutor&) = delete;
@@ -45,5 +45,5 @@ class CommandExecutor {
   }
 
  private:
-  std::unique_ptr<FILE, decltype(&PCLOSE)> m_pipe{nullptr, PCLOSE};
+  std::unique_ptr<FILE, int (*)(FILE*)> m_pipe{nullptr, PCLOSE};
 };


### PR DESCRIPTION
## Describe Your Changes

-The warning was triggered by using `decltype(&PCLOSE)` to deduce the deleter type for the `std::unique_ptr` member `m_pipe`. While `decltype(&PCLOSE)` correctly deduces the function pointer type, the compiler flags this as a potential issue because attributes associated with the function pointer type (if any existed in the definition of `PCLOSE`) are ignored when used as a template argument.
To resolve this warning, the deleter type for `std::unique_ptr` is now explicitly specified as `int (*)(FILE*)`. This directly states the function pointer type expected for `PCLOSE` and avoids the attribute deduction issue.

This is a code quality improvement and does not change the functionality of the `CommandExecutor` class. It only modifies the type declaration of the `m_pipe` member.
