### PR TITLE
fix: -Wreorder warning in DownloadService constructor

### DIFF
--- a/engine/services/download_service.h
+++ b/engine/services/download_service.h
@@ -87,7 +87,7 @@ class DownloadService {
 
   explicit DownloadService(std::shared_ptr<EventQueue> event_queue,
                            std::shared_ptr<ConfigService> config_service)
-      : event_queue_{event_queue}, config_service_{config_service} {
+      : config_service_{config_service}, event_queue_{event_queue}  {
     InitializeWorkers();
   };
 


### PR DESCRIPTION
## Describe Your Changes

- This PR addresses a -Wreorder warning in the DownloadService class constructor. The compiler issues a warning because the member initializers in the DownloadService constructor's initializer list are not in the same order as the member declarations within the class definition. This PR reorders the member initializers in the DownloadService constructor to match the declaration order in the class definition.
This resolves -Wreorder warning, and improves the code clarity.