### PR TITLE
feat: remote embeddings

### DIFF
--- a/engine/extensions/remote-engine/remote_engine.h
+++ b/engine/extensions/remote-engine/remote_engine.h
@@ -34,6 +34,8 @@ struct CurlResponse {
   std::string error_message;
 };
 
+enum class RequestType { kChatCompletions, kEmbeddings };
+
 class RemoteEngine : public RemoteEngineI {
  protected:
   // Model configuration
@@ -58,11 +60,15 @@ class RemoteEngine : public RemoteEngineI {
   std::string engine_name_;
   std::string chat_url_;
   trantor::ConcurrentTaskQueue q_;
+  // TODO(sang)
+  std::string embed_req_template_;
+  std::string embed_res_template_;
+  std::string embed_url_;
 
   // Helper functions
-  CurlResponse MakeChatCompletionRequest(const ModelConfig& config,
-                                         const std::string& body,
-                                         const std::string& method = "POST");
+  CurlResponse MakeNonStreamRequest(
+      const ModelConfig& config, const std::string& body,
+      const RequestType& req_type = RequestType::kChatCompletions);
   CurlResponse MakeStreamingChatCompletionRequest(
       const ModelConfig& config, const std::string& body,
       const std::function<void(Json::Value&&, Json::Value&&)>& callback);


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces several changes to the `RemoteEngine` class in the `engine/extensions/remote-engine/remote_engine.cc` file, primarily focusing on refactoring and adding support for embeddings. The key modifications include the introduction of a new `RequestType` enum, replacing hardcoded strings with constants, and refactoring functions to handle different request types.

### Refactoring and Constants:

* Added constants `kChatCompletions` and `kEmbeddings` to replace hardcoded strings for request types. (`engine/extensions/remote-engine/remote_engine.cc`)
* Replaced hardcoded strings with `kChatCompletions` in various locations to improve code readability and maintainability. (`engine/extensions/remote-engine/remote_engine.cc`) [[1]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L120-R124) [[2]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L137-R143) [[3]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L572-R605) [[4]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L638-R672)

### Function Refactoring:

* Refactored `MakeChatCompletionRequest` to `MakeNonStreamRequest` to handle both chat completions and embeddings based on the new `RequestType` enum. (`engine/extensions/remote-engine/remote_engine.cc`) [[1]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L286-R290) [[2]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L297-R313)
* Updated `HandleChatCompletion` to use the refactored `MakeNonStreamRequest` function. (`engine/extensions/remote-engine/remote_engine.cc`)

### Embeddings Support:

* Added handling for embedding requests and responses, including new templates and URLs for embeddings. (`engine/extensions/remote-engine/remote_engine.cc`) [[1]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L435-R487) [[2]](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L725-R906)
* Introduced new member variables `embed_req_template_`, `embed_res_template_`, and `embed_url_` to store embedding-specific configurations. (`engine/extensions/remote-engine/remote_engine.h`)

### Error Handling and Logging:

* Enhanced error handling and logging for missing required fields and template rendering errors in `HandleEmbedding`. (`engine/extensions/remote-engine/remote_engine.cc`)

These changes improve the code structure, readability, and extend the functionality of the `RemoteEngine` class to support embeddings alongside chat completions.

## Fixes Issues

- https://github.com/janhq/cortex.cpp/issues/2088

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed