### PR TITLE
fix: Remove unnecessary std::move from temporary objects in Text struct

### DIFF
--- a/engine/common/message_content_text.h
+++ b/engine/common/message_content_text.h
@@ -148,9 +148,9 @@ struct Text : JsonSerializable {
       // Parse annotations array
       if (json.isMember("annotations") && json["annotations"].isArray()) {
         for (const auto& annotation_json : json["annotations"]) {
-          std::string type = std::move(annotation_json["type"].asString());
+          std::string type = annotation_json["type"].asString();
           std::string annotation_text =
-              std::move(annotation_json["text"].asString());
+              annotation_json["text"].asString();
           uint32_t start_index = annotation_json["start_index"].asUInt();
           uint32_t end_index = annotation_json["end_index"].asUInt();
 


### PR DESCRIPTION
## Describe Your Changes

- This pull request addresses a compiler warning related to moving temporary objects in the Text struct's annotation parsing logic. The changes involve removing std::move calls from the assignment of temporary strings returned by asString() for both the type and annotation_text variables.

Using std::move on temporary objects can prevent copy elision and lead to potential issues in the code. By directly assigning the result of asString() to the respective variables, we ensure that the code is cleaner and free from unnecessary moves, thus keeping the compiler happy.

