### PR TITLE
fix: Exception Handling and multiline comment

### DIFF
--- a/engine/common/message_content_text.h
+++ b/engine/common/message_content_text.h
@@ -192,7 +192,7 @@ struct Text : JsonSerializable {
       }
       json["annotations"] = annotations_json_arr;
       return json;
-    } catch (const std::exception e) {
+    } catch (const std::exception & e) {
       return cpp::fail(std::string("ToJson failed: ") + e.what());
     }
   };

--- a/engine/utils/hardware/gguf/gguf_file.h
+++ b/engine/utils/hardware/gguf/gguf_file.h
@@ -25,11 +25,12 @@
 #include "ggml.h"
 #include "utils/logging_utils.h"
 #include "utils/string_utils.h"
-
-// #define GGUF_LOG(msg)                                                  \
-//   do {                                                                 \
-//     std::cout << __FILE__ << "(@" << __LINE__ << "): " << msg << '\n'; \
-//   } while (false)
+/*
+#define GGUF_LOG(msg)                                                  \
+  do {                                                                 \
+    std::cout << __FILE__ << "(@" << __LINE__ << "): " << msg << '\n'; \
+  } while (false)
+*/
 
 #define GGUF_LOG(msg)
 namespace hardware {


### PR DESCRIPTION
## Describe Your Changes

- This pull request addresses two key improvements in the codebase:

    - Exception Handling Improvement:
Updated the exception handling in the Text struct's ToJson method. The catch clause now correctly captures the exception by reference (const std::exception & e) instead of by value. This change prevents unnecessary copying of the exception object and adheres to best practices for exception handling in C++.
    - Logging Code multiline comment fix:
Commented out the unused GGUF_LOG macro in gguf_file.cpp using a block comment to resolve compiler complaints about multiline comments.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed