### PR TITLE
fix: delete model for remote engine

### DIFF
--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -757,12 +757,17 @@ cpp::result<void, std::string> ModelService::DeleteModel(
         fs::path(model_entry.value().path_to_model_yaml));
     yaml_handler.ModelConfigFromFile(yaml_fp.string());
     auto mc = yaml_handler.GetModelConfig();
-    // Remove yaml files
-    for (const auto& entry :
-         std::filesystem::directory_iterator(yaml_fp.parent_path())) {
-      if (entry.is_regular_file() && (entry.path().extension() == ".yml")) {
-        std::filesystem::remove(entry);
-        CTL_INF("Removed: " << entry.path().string());
+    if (engine_svc_->IsRemoteEngine(mc.engine)) {
+      std::filesystem::remove(yaml_fp);
+      CTL_INF("Removed: " << yaml_fp.string());
+    } else {
+      // Remove yaml files
+      for (const auto& entry :
+           std::filesystem::directory_iterator(yaml_fp.parent_path())) {
+        if (entry.is_regular_file() && (entry.path().extension() == ".yml")) {
+          std::filesystem::remove(entry);
+          CTL_INF("Removed: " << entry.path().string());
+        }
       }
     }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `ModelService::DeleteModel` method in the `engine/services/model_service.cc` file. The most important changes involve adding a condition to handle the removal of YAML files for remote engines.

Changes in `ModelService::DeleteModel`:

* Added a condition to check if the engine is remote using `engine_svc_->IsRemoteEngine(mc.engine)`. If true, the YAML file is removed and a log message is printed.
* Ensured the existing logic for removing YAML files is executed only for non-remote engines.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed