### PR TITLE
fix: all leftover warnings on Linux

### DIFF
--- a/engine/common/assistant_code_interpreter_tool.h
+++ b/engine/common/assistant_code_interpreter_tool.h
@@ -20,7 +20,7 @@ struct AssistantCodeInterpreterTool : public AssistantTool {
 
   static cpp::result<AssistantCodeInterpreterTool, std::string> FromJson() {
     AssistantCodeInterpreterTool tool;
-    return std::move(tool);
+    return tool;
   }
 
   cpp::result<Json::Value, std::string> ToJson() override {

--- a/engine/common/thread.h
+++ b/engine/common/thread.h
@@ -150,9 +150,11 @@ struct Thread : JsonSerializable {
         if (auto code_interpreter =
                 dynamic_cast<CodeInterpreter*>(tool_resources.get())) {
           tool_json["code_interpreter"] = tool_result.value();
+          (void) code_interpreter;
         } else if (auto file_search =
                        dynamic_cast<FileSearch*>(tool_resources.get())) {
           tool_json["file_search"] = tool_result.value();
+          (void) file_search;
         }
         json["tool_resources"] = tool_json;
       }

--- a/engine/extensions/python-engine/python_engine.cc
+++ b/engine/extensions/python-engine/python_engine.cc
@@ -56,7 +56,7 @@ size_t StreamWriteCallback(char* ptr, size_t size, size_t nmemb,
   return size * nmemb;
 }
 
-static size_t WriteCallback(char* ptr, size_t size, size_t nmemb,
+[[maybe_unused]] static size_t WriteCallback(char* ptr, size_t size, size_t nmemb,
                             std::string* data) {
   data->append(ptr, size * nmemb);
   return size * nmemb;
@@ -185,6 +185,7 @@ void PythonEngine::GetModels(
   status["status_code"] = k200OK;
 
   callback(std::move(status), std::move(response_json));
+  (void) json_body;
 }
 
 void PythonEngine::LoadModel(
@@ -386,6 +387,8 @@ void PythonEngine::HandleChatCompletion(
     std::shared_ptr<Json::Value> json_body,
     std::function<void(Json::Value&&, Json::Value&&)>&& callback) {
   LOG_WARN << "Does not support yet!";
+  (void) json_body;
+  (void) callback;
 }
 
 CurlResponse PythonEngine::MakeStreamPostRequest(
@@ -623,7 +626,9 @@ Json::Value PythonEngine::GetRemoteModels() {
   return Json::Value();
 }
 
-void PythonEngine::StopInferencing(const std::string& model_id) {}
+void PythonEngine::StopInferencing(const std::string& model_id) {
+  (void)model_id;
+}
 
 void PythonEngine::HandleRouteRequest(
     std::shared_ptr<Json::Value> json_body,
@@ -893,12 +898,14 @@ void PythonEngine::SetLogLevel(trantor::Logger::LogLevel log_level) {
 
 void PythonEngine::Load(EngineLoadOption opts) {
   // Develop register model here on loading engine
+  (void) opts;
 };
 
 void PythonEngine::Unload(EngineUnloadOption opts) {
   for (const auto& pair : models_) {
     TerminateModelProcess(pair.first);
   }
+  (void) opts;
 };
 
 }  // namespace python_engine

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -63,7 +63,7 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
                bool ignore_cout) {
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
   auto signal_handler = +[](int sig) -> void {
-    std::cout << "\rCaught interrupt signal, shutting down\n";
+    std::cout << "\rCaught interrupt signal:" << sig << ", shutting down\n";;
     shutdown_signal = true;
   };
   signal(SIGINT, signal_handler);
@@ -145,7 +145,7 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
     return;
   }
 
-  using Event = cortex::event::Event;
+  // using Event = cortex::event::Event; //unused
   using EventQueue =
       eventpp::EventQueue<EventType,
                           void(const eventpp::AnyData<eventMaxSize>&)>;

--- a/engine/services/download_service.h
+++ b/engine/services/download_service.h
@@ -234,6 +234,8 @@ class DownloadService {
         break;
       }
     }
+    (void) ultotal;
+    (void) ulnow;
 
     return 0;
   }

--- a/engine/utils/cortex_utils.h
+++ b/engine/utils/cortex_utils.h
@@ -30,8 +30,8 @@ inline std::string logs_cli_base_name = "./logs/cortex-cli.log";
 // example: Mon, 25 Nov 2024 09:57:03 GMT
 inline std::string GetDateRFC1123() {
   std::time_t now = std::time(nullptr);
-  std::tm gmt_time = {};
 #ifdef _MSC_VER
+  std::tm gmt_time = {};
   gmtime_s(&gmt_time, &now);
   std::ostringstream oss;
   oss << std::put_time(&gmt_time, "%a, %d %b %Y %H:%M:%S GMT");
@@ -133,7 +133,7 @@ inline std::string GetCurrentPath() {
 #else
   std::vector<char> buf(PATH_MAX);
   ssize_t len = readlink("/proc/self/exe", &buf[0], buf.size());
-  if (len == -1 || len == buf.size()) {
+  if (len == -1 || len == (ssize_t) buf.size()) {
     std::cerr << "Error reading symlink /proc/self/exe." << std::endl;
     return "";
   }

--- a/engine/utils/file_logger.cc
+++ b/engine/utils/file_logger.cc
@@ -54,7 +54,7 @@ void FileLogger::CircularLogFile::writeLog(const char* logLine,
     lineBuffer_.push_back(line);
     AppendToFile(line + "\n");
     ++linesWrittenSinceLastTruncate_;
-    if (linesWrittenSinceLastTruncate_.load() >= TRUNCATE_CHECK_INTERVAL) {
+    if (static_cast<uint64_t>(linesWrittenSinceLastTruncate_.load()) >= TRUNCATE_CHECK_INTERVAL) {
 
       TruncateFileIfNeeded();
     }

--- a/engine/utils/github_release_utils.h
+++ b/engine/utils/github_release_utils.h
@@ -168,6 +168,7 @@ inline cpp::result<std::vector<GitHubRelease>, std::string> GetReleases(
   for (const auto& release : result.value()) {
     releases.push_back(GitHubRelease::FromJson(release));
   }
+  (void) allow_prerelease;
   return releases;
 }
 

--- a/engine/utils/hardware/gguf/gguf_file.h
+++ b/engine/utils/hardware/gguf/gguf_file.h
@@ -539,6 +539,7 @@ inline std::optional<GGUFFile> ParseGgufFile(const std::string& path) {
     }
     gf.tensor_infos = tis;
   }
+  (void) version;
   return gf;
 }
 }  // namespace hardware

--- a/engine/utils/url_parser.h
+++ b/engine/utils/url_parser.h
@@ -93,7 +93,7 @@ inline cpp::result<Url, std::string> FromUrlString(
       .host = "",
       .pathParams = {},
   };
-  unsigned counter = 0;
+  int counter = 0;
 
   std::smatch url_match_result;
 


### PR DESCRIPTION
## Describe Your Changes

- This PR fixes various compiler warnings on Linux. The changes include:

* Suppressing unused parameter warnings by adding `(void)` casts
* Adding `[[maybe_unused]]` attributes to unused functions and variables
* Fixing signed/unsigned comparison warnings by casting to a common type
* Removing unused type aliases and variables
* Updating code to fix warnings about unused variables and functions

This should address almost all warnings for now.

The only thing left is complaints about C++20 designated initializers on Linux which I plan to fix later.