### PR TITLE
chore: use non-cuda variant for e2e tests

### DIFF
--- a/engine/e2e-test/api/engines/test_api_engine.py
+++ b/engine/e2e-test/api/engines/test_api_engine.py
@@ -28,7 +28,7 @@ class TestApiEngine:
         
     # engines install
     def test_engines_install_llamacpp_specific_version_and_variant(self):
-        data = {"version": "v0.1.40-b4354", "variant": "linux-amd64-avx-cuda-11-7"}
+        data = {"version": "v0.1.40-b4354", "variant": "linux-amd64-avx"}
         response = requests.post(
             "http://localhost:3928/v1/engines/llama-cpp/install", json=data
         )

--- a/engine/e2e-test/api/engines/test_api_engine_install_nightly.py
+++ b/engine/e2e-test/api/engines/test_api_engine_install_nightly.py
@@ -23,7 +23,7 @@ class TestApiEngineInstall:
         assert response.status_code == 200
 
     def test_engines_install_llamacpp_specific_version_and_variant(self):
-        data = {"version": latest_pre_release_tag, "variant": "linux-amd64-avx-cuda-11-7"}
+        data = {"version": latest_pre_release_tag, "variant": "linux-amd64-avx"}
         response = requests.post(
             "http://localhost:3928/v1/engines/llama-cpp/install", json=data
         )

--- a/engine/e2e-test/api/engines/test_api_get_default_engine.py
+++ b/engine/e2e-test/api/engines/test_api_get_default_engine.py
@@ -24,7 +24,7 @@ class TestApiDefaultEngine:
     def test_api_get_default_engine_successfully(self):
         # Data test
         engine= "llama-cpp"
-        name= "linux-amd64-avx-cuda-11-7"
+        name= "linux-amd64-avx"
         version= "v0.1.35-27.10.24"
     
         data = {"version": version, "variant": name}


### PR DESCRIPTION
## Describe Your Changes

This pull request includes updates to the engine installation tests to change the variant of the `llama-cpp` engine. The changes ensure that the tests now use the `linux-amd64-avx` variant instead of the previous `linux-amd64-avx-cuda-11-7` variant.

Changes to engine installation tests:

* [`engine/e2e-test/api/engines/test_api_engine.py`](diffhunk://#diff-d05c89e39b7754cded9a0f9f8bb57878b8970e9455277d1a9f671133f71c995aL31-R31): Updated the `test_engines_install_llamacpp_specific_version_and_variant` method to use the `linux-amd64-avx` variant.
* [`engine/e2e-test/api/engines/test_api_engine_install_nightly.py`](diffhunk://#diff-c0cd9d5f3ac7e32306b077be6178e6d3702adbee985be85785ac47a484d77efcL26-R26): Updated the `test_engines_install_llamacpp_specific_version_and_variant` method to use the `linux-amd64-avx` variant.
* [`engine/e2e-test/api/engines/test_api_get_default_engine.py`](diffhunk://#diff-b65b1732e01748799f27fc8c32ea1f10f3b68803900b70b4277255ce4fedf714L27-R27): Updated the `test_api_get_default_engine_successfully` method to use the `linux-amd64-avx` variant.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed