### PR TITLE
chore: remove engine before installing for e2e test

### DIFF
--- a/engine/e2e-test/api/engines/test_api_get_list_engine.py
+++ b/engine/e2e-test/api/engines/test_api_get_list_engine.py
@@ -26,6 +26,11 @@ class TestApiEngineList:
         engine= "llama-cpp"
         name= "linux-amd64-avx"
         version= "v0.1.35-27.10.24"
+        
+        post_install_url = f"http://localhost:3928/v1/engines/{engine}/install"
+        response = requests.delete(
+            post_install_url
+        )
     
         data = {"version": version, "variant": name}
         post_install_url = f"http://localhost:3928/v1/engines/{engine}/install"


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `engine/e2e-test/api/engines/test_api_get_list_engine.py` file to ensure that any previous installations of an engine are cleaned up before a new installation is attempted.

* Added a `DELETE` request to remove any existing installation of the engine before making a `POST` request to install a new version.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed