### PR TITLE
fix: update career url

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -476,7 +476,7 @@ const config: Config = {
             },
             {
               label: "Careers",
-              href: "https://homebrew.bamboohr.com/careers",
+              href: "https://menlo.bamboohr.com/careers",
             },
           ],
         },


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `docs/docusaurus.config.ts` file. The change updates the "Careers" link to point to the correct URL.

* [`docs/docusaurus.config.ts`](diffhunk://#diff-9dbe126a5a498e56dcf30f25d7fc163f8443517db03458905d3d33303e1cdbf9L479-R479): Updated the "Careers" link from "https://homebrew.bamboohr.com/careers" to "https://menlo.bamboohr.com/careers".

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed