### PR TITLE
fix: get models for anthropic and cohere

### DIFF
--- a/engine/extensions/remote-engine/remote_engine.cc
+++ b/engine/extensions/remote-engine/remote_engine.cc
@@ -713,8 +713,22 @@ Json::Value RemoteEngine::GetRemoteModels(const std::string& url,
     }
     CTL_DBG(response.body);
     auto body_json = json_helper::ParseJsonString(response.body);
-    if (body_json.isMember("error")) {
+    if (body_json.isMember("error") && !body_json["error"].isNull()) {
       return body_json["error"];
+    }
+
+    // hardcode for cohere
+    if (url.find("api.cohere.ai") != std::string::npos) {
+      if (body_json.isMember("models")) {
+        for (auto& model : body_json["models"]) {
+          if (model.isMember("name")) {
+            model["id"] = model["name"];
+            model.removeMember("name");
+          }
+        }
+        body_json["data"] = body_json["models"];
+        body_json.removeMember("models");
+      }
     }
     return body_json;
   }

--- a/engine/extensions/remote-engine/remote_engine.cc
+++ b/engine/extensions/remote-engine/remote_engine.cc
@@ -252,11 +252,14 @@ CurlResponse RemoteEngine::MakeGetModelsRequest(
     return response;
   }
 
-  std::string api_key_header =
-      ReplaceApiKeyPlaceholder(header_template, api_key);
+  std::unordered_map<std::string, std::string> replacements = {
+      {"api_key", api_key}};
+  auto hs = ReplaceHeaderPlaceholders(header_template, replacements);
 
   struct curl_slist* headers = nullptr;
-  headers = curl_slist_append(headers, api_key_header.c_str());
+  for (auto const& h : hs) {
+    headers = curl_slist_append(headers, h.c_str());
+  }
   headers = curl_slist_append(headers, "Content-Type: application/json");
 
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -699,25 +702,7 @@ Json::Value RemoteEngine::GetRemoteModels(const std::string& url,
                                           const std::string& api_key,
                                           const std::string& header_template) {
   if (url.empty()) {
-    if (engine_name_ == kAnthropicEngine) {
-      Json::Value json_resp;
-      Json::Value model_array(Json::arrayValue);
-      for (const auto& m : kAnthropicModels) {
-        Json::Value val;
-        val["id"] = std::string(m);
-        val["engine"] = "anthropic";
-        val["created"] = "_";
-        val["object"] = "model";
-        model_array.append(val);
-      }
-
-      json_resp["object"] = "list";
-      json_resp["data"] = model_array;
-      CTL_INF("Remote models responded");
-      return json_resp;
-    } else {
-      return Json::Value();
-    }
+    return Json::Value();
   } else {
     auto response = MakeGetModelsRequest(url, api_key, header_template);
     if (response.error) {

--- a/engine/utils/engine_constants.h
+++ b/engine/utils/engine_constants.h
@@ -3,10 +3,6 @@
 constexpr const auto kLlamaEngine = "llama-cpp";
 constexpr const auto kPythonEngine = "python-engine";
 
-constexpr const auto kOpenAiEngine = "openai";
-constexpr const auto kAnthropicEngine = "anthropic";
-
-
 constexpr const auto kRemote = "remote";
 constexpr const auto kLocal = "local";
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `remote-engine` component in the `engine/extensions` directory to improve the handling of API key headers and remove specific engine-related constants and logic. The most important changes include refactoring header handling, removing special handling for the `kAnthropicEngine`, and cleaning up unused constants.

Improvements to header handling:

* [`engine/extensions/remote-engine/remote_engine.cc`](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L255-R262): Refactored the `MakeGetModelsRequest` method to use a more flexible approach for replacing header placeholders using an unordered map and a loop to append headers.

Codebase simplification:

* [`engine/extensions/remote-engine/remote_engine.cc`](diffhunk://#diff-5e18e257cc1a4ad1b2503e5b4f0d50c3e958671efeee708881d95a9a18475ea8L702-L720): Removed the special handling for the `kAnthropicEngine` in the `GetRemoteModels` method, simplifying the code path for empty URLs.
* [`engine/utils/engine_constants.h`](diffhunk://#diff-554e65ded205bbc0838d96e605369282d457c4dfdb293cf1eeb94f92d1a598e5L6-L9): Removed unused constants `kOpenAiEngine` and `kAnthropicEngine` to clean up the codebase.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed