### PR TITLE
chore: Remove supported_engines check in CLI

### DIFF
--- a/engine/cli/command_line_parser.h
+++ b/engine/cli/command_line_parser.h
@@ -25,11 +25,6 @@ class CommandLineParser {
 
   void SetupConfigsCommands();
 
-  void EngineInstall(CLI::App* parent, const std::string& engine_name,
-                     std::string& version, std::string& src);
-
-  void EngineUninstall(CLI::App* parent, const std::string& engine_name);
-
   void EngineUpdate(CLI::App* parent, const std::string& engine_name);
 
   void EngineGet(CLI::App* parent);
@@ -54,6 +49,7 @@ class CommandLineParser {
     std::string msg;
     std::string model_alias;
     std::string model_path;
+    std::string engine_name;
     std::string engine_version = "latest";
     std::string engine_src;
     std::string cortex_version;

--- a/engine/cli/command_line_parser.h
+++ b/engine/cli/command_line_parser.h
@@ -25,16 +25,6 @@ class CommandLineParser {
 
   void SetupConfigsCommands();
 
-  void EngineUpdate(CLI::App* parent, const std::string& engine_name);
-
-  void EngineGet(CLI::App* parent);
-
-  void EngineUse(CLI::App* parent, const std::string& engine_name);
-
-  void EngineLoad(CLI::App* parent, const std::string& engine_name);
-
-  void EngineUnload(CLI::App* parent, const std::string& engine_name);
-
   void ModelUpdate(CLI::App* parent);
 
   CLI::App app_;
@@ -42,7 +32,6 @@ class CommandLineParser {
   std::shared_ptr<cortex::DylibPathManager> dylib_path_manager_;
   std::shared_ptr<DatabaseService> db_service_;
   std::shared_ptr<EngineService> engine_service_;
-  std::vector<std::string> supported_engines_;
 
   struct CmlData {
     std::string model_id;


### PR DESCRIPTION
## Describe Your Changes

Closes #1962

For context:
- There is no good reason why CLI should only allow installing engines prescribed in `.cortexrc`'s `supportedEngines`. The check should be done on the server-side.
- This makes it easier to add new engines e.g. upcoming Python vLLM engine #2010. This is because if the user doesn't update his `.cortexrc`, doing something like `cortex engines install vllm` will fail otherwise (and we need to add code to somehow update `.cortexrc` automatically)

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed