### PR TITLE
fix: enable follow location option for get request

### DIFF
--- a/engine/utils/curl_utils.cc
+++ b/engine/utils/curl_utils.cc
@@ -147,6 +147,7 @@ cpp::result<std::string, std::string> SimpleGet(const std::string& url,
                                   std::default_delete<CurlResponse>());
 
   SetUpProxy(curl, url);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlResponse::WriteCallback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small but important change to the `SimpleGet` function in the `engine/utils/curl_utils.cc` file. The change ensures that the `curl` request will automatically follow HTTP redirects.

* [`engine/utils/curl_utils.cc`](diffhunk://#diff-71e2f0919cb74597dccf51a26adc09b06faed73484bfdfe847ee9a4ac14de4d0R150): Added `CURLOPT_FOLLOWLOCATION` option to the `curl_easy_setopt` call to follow HTTP redirects.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed