### PR TITLE
refactor: rename org to menloresearch

### DIFF
--- a/.github/ISSUE_TEMPLATE/QA_checklist.md
+++ b/.github/ISSUE_TEMPLATE/QA_checklist.md
@@ -70,7 +70,7 @@ OS (select one)
 ## Server
 - [ ] `cortex start` should start server and output localhost URL & port number
 - [ ] users can access API Swagger documentation page  at localhost URL & port number
-- [ ] `cortex start` can be configured with parameters (port, [logLevel [WIP]](https://github.com/janhq/cortex.cpp/pull/1636)) https://cortex.so/docs/cli/start/
+- [ ] `cortex start` can be configured with parameters (port, [logLevel [WIP]](https://github.com/menloresearch/cortex.cpp/pull/1636)) https://cortex.so/docs/cli/start/
 - [ ]  it should correctly log to cortex logs (logs/cortex.log, logs/cortex-cli.log)
 - [ ]  `cortex ps` should return server status and running models (or no model loaded)
 - [ ]  `cortex stop` should stop server

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,5 +3,5 @@ blank_issues_enabled: true
 
 contact_links:
   - name: "\1F4AC Cortex Discussions"
-    url: "https://github.com/orgs/janhq/discussions/categories/q-a"
+    url: "https://github.com/orgs/menloresearch/discussions/categories/q-a"
     about: "Get help, discuss features & roadmap, and share your projects"

--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -145,20 +145,20 @@ jobs:
           message: |
             Cortex.cpp beta build artifact version ${{ env.VERSION }}:
             - Windows:
-              - Network Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-windows-amd64-network-installer.exe
-              - Local Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-windows-amd64-local-installer.exe
-              - Binary: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-windows-amd64.tar.gz
+              - Network Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-windows-amd64-network-installer.exe
+              - Local Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-windows-amd64-local-installer.exe
+              - Binary: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-windows-amd64.tar.gz
             - macOS Universal:
-              - Network Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-mac-universal-network-installer.pkg
-              - Local Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-mac-universal-local-installer.pkg
-              - Binary: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-mac-universal.tar.gz
+              - Network Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-mac-universal-network-installer.pkg
+              - Local Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-mac-universal-local-installer.pkg
+              - Binary: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-mac-universal.tar.gz
             - Linux amd64 Deb:
-              - Network Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-amd64-network-installer.deb
-              - Local Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-amd64-local-installer.deb
-              - Binary: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-amd64.tar.gz
+              - Network Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-amd64-network-installer.deb
+              - Local Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-amd64-local-installer.deb
+              - Binary: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-amd64.tar.gz
             - Linux arm64 Deb:
-              - Network Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-arm64-network-installer.deb
-              - Local Installer: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-arm64-local-installer.deb
-              - Binary: https://github.com/janhq/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-arm64.tar.gz
+              - Network Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-arm64-network-installer.deb
+              - Local Installer: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-arm64-local-installer.deb
+              - Binary: https://github.com/menloresearch/cortex.cpp/releases/download/v${{ env.VERSION }}/cortex-${{ env.VERSION }}-linux-arm64.tar.gz
             - Docker: menloltd/cortex:beta-${{ env.VERSION }}
-            - Github Release: https://github.com/janhq/cortex.cpp/releases/tag/v${{ env.VERSION }}
+            - Github Release: https://github.com/menloresearch/cortex.cpp/releases/tag/v${{ env.VERSION }}

--- a/.github/workflows/template-build-linux.yml
+++ b/.github/workflows/template-build-linux.yml
@@ -169,23 +169,23 @@ jobs:
           mkdir -p engine/templates/linux/dependencies
           cd engine/templates/linux/dependencies
           if [ "${{ inputs.arch }}" == "amd64" ]; then
-            # wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx-cuda-11-7.tar.gz
-            # wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx-cuda-12-0.tar.gz
-            # wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx2-cuda-11-7.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx2-cuda-12-0.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx2.tar.gz
-            # wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx512-cuda-11-7.tar.gz
-            # wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx512-cuda-12-0.tar.gz
-            # wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx512.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-noavx-cuda-11-7.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-noavx-cuda-12-0.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-noavx.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-vulkan.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-11-7-linux-amd64.tar.gz
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-12-0-linux-amd64.tar.gz
+            # wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx-cuda-11-7.tar.gz
+            # wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx-cuda-12-0.tar.gz
+            # wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx2-cuda-11-7.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx2-cuda-12-0.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx2.tar.gz
+            # wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx512-cuda-11-7.tar.gz
+            # wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx512-cuda-12-0.tar.gz
+            # wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-avx512.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-noavx-cuda-11-7.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-noavx-cuda-12-0.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-noavx.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-amd64-vulkan.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-11-7-linux-amd64.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-12-0-linux-amd64.tar.gz
           else
-            wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-arm64.tar.gz
+            wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-linux-arm64.tar.gz
           fi
           cd ..
 

--- a/.github/workflows/template-build-macos.yml
+++ b/.github/workflows/template-build-macos.yml
@@ -289,8 +289,8 @@ jobs:
         run: |
           mkdir -p engine/templates/macos/Scripts/dependencies
           cd engine/templates/macos/Scripts/dependencies
-          wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-mac-arm64.tar.gz
-          wget https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-mac-amd64.tar.gz
+          wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-mac-arm64.tar.gz
+          wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-mac-amd64.tar.gz
 
           cd ../../
           chmod +x create_pkg_local.sh

--- a/.github/workflows/template-build-windows-x64.yml
+++ b/.github/workflows/template-build-windows-x64.yml
@@ -205,21 +205,21 @@ jobs:
         run: |
           mkdir dependencies
           cd dependencies
-          # wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx-cuda-11-7.tar.gz
-          # wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx-cuda-12-0.tar.gz
-          # wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx2-cuda-11-7.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx2-cuda-12-0.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx2.tar.gz
-          # wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx512-cuda-11-7.tar.gz
-          # wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx512-cuda-12-0.tar.gz
-          # wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx512.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-noavx-cuda-11-7.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-noavx-cuda-12-0.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-noavx.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-vulkan.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-11-7-windows-amd64.tar.gz
-          wget.exe https://github.com/janhq/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-12-0-windows-amd64.tar.gz
+          # wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx-cuda-11-7.tar.gz
+          # wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx-cuda-12-0.tar.gz
+          # wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx2-cuda-11-7.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx2-cuda-12-0.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx2.tar.gz
+          # wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx512-cuda-11-7.tar.gz
+          # wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx512-cuda-12-0.tar.gz
+          # wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-avx512.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-noavx-cuda-11-7.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-noavx-cuda-12-0.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-noavx.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cortex.llamacpp-${{ inputs.cortex-llamacpp-version }}-windows-amd64-vulkan.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-11-7-windows-amd64.tar.gz
+          wget.exe https://github.com/menloresearch/cortex.llamacpp/releases/download/v${{ inputs.cortex-llamacpp-version }}/cuda-12-0-windows-amd64.tar.gz
 
       - name: Enable long paths
         run: |

--- a/.github/workflows/template-cortex-llamacpp-latest-version.yml
+++ b/.github/workflows/template-cortex-llamacpp-latest-version.yml
@@ -24,7 +24,7 @@ jobs:
           local max_retries=3
           local tag
           while [ $retries -lt $max_retries ]; do
-            tag=$(curl -s https://api.github.com/repos/janhq/cortex.llamacpp/releases/latest | jq -r .tag_name)
+            tag=$(curl -s https://api.github.com/repos/menloresearch/cortex.llamacpp/releases/latest | jq -r .tag_name)
             if [ -n "$tag" ] && [ "$tag" != "null" ]; then
               echo $tag
               return

--- a/.github/workflows/template-get-update-version.yml
+++ b/.github/workflows/template-get-update-version.yml
@@ -31,7 +31,7 @@ jobs:
           local max_retries=3
           local tag
           while [ $retries -lt $max_retries ]; do
-            tag=$(curl -s https://api.github.com/repos/janhq/cortex.cpp/releases/latest | jq -r .tag_name)
+            tag=$(curl -s https://api.github.com/repos/menloresearch/cortex.cpp/releases/latest | jq -r .tag_name)
             if [ -n "$tag" ] && [ "$tag" != "null" ]; then
               echo $tag
               return

--- a/.github/workflows/template-noti-discord.yaml
+++ b/.github/workflows/template-noti-discord.yaml
@@ -43,4 +43,4 @@ jobs:
               - Local Installer: https://delta.jan.ai/cortex/v${{ env.VERSION }}/linux-amd64/cortex-${{ env.VERSION }}-linux-amd64-local-installer.deb
               - Binary: https://delta.jan.ai/cortex/v${{ env.VERSION }}/linux-amd64/cortex-nightly.tar.gz
             - Docker: menloltd/cortex:nightly-${{ env.VERSION }}
-            - Github action run: https://github.com/janhq/cortex.cpp/actions/runs/${{ env.RUNNER_ID }}
+            - Github action run: https://github.com/menloresearch/cortex.cpp/actions/runs/${{ env.RUNNER_ID }}

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,9 +1,9 @@
 # Build Cortex.cpp from source
 
-Firstly, clone the Cortex.cpp repository [here](https://github.com/janhq/cortex.cpp) and initialize the submodules:
+Firstly, clone the Cortex.cpp repository [here](https://github.com/menloresearch/cortex.cpp) and initialize the submodules:
 
 ```bash
-git clone https://github.com/janhq/cortex.cpp
+git clone https://github.com/menloresearch/cortex.cpp
 cd cortex.cpp
 git submodule update --init --recursive
 ```
@@ -73,7 +73,7 @@ make -j4
 
 1. Open Cortex.cpp repository in Codespaces or local devcontainer
 
-    [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/janhq/cortex.cpp?quickstart=1)
+    [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/menloresearch/cortex.cpp?quickstart=1)
 
     ```sh
     devcontainer up --workspace-folder .

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 </p>
 
 <p align="center">
-  <img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/janhq/cortex.cpp"/>
-  <img alt="Github Last Commit" src="https://img.shields.io/github/last-commit/janhq/cortex.cpp"/>
-  <img alt="Github Contributors" src="https://img.shields.io/github/contributors/janhq/cortex.cpp"/>
+  <img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/menloresearch/cortex.cpp"/>
+  <img alt="Github Last Commit" src="https://img.shields.io/github/last-commit/menloresearch/cortex.cpp"/>
+  <img alt="Github Contributors" src="https://img.shields.io/github/contributors/menloresearch/cortex.cpp"/>
   <img alt="Discord" src="https://img.shields.io/discord/1107178041848909847?label=discord"/>
 </p>
 
 <p align="center">
   <a href="https://cortex.so/docs/">Docs</a> •
   <a href="https://cortex.so/api-reference">API Reference</a> •
-  <a href="https://github.com/janhq/cortex.cpp/releases">Changelog</a> •
-  <a href="https://github.com/janhq/cortex.cpp/issues">Issues</a> •
+  <a href="https://github.com/menloresearch/cortex.cpp/releases">Changelog</a> •
+  <a href="https://github.com/menloresearch/cortex.cpp/issues">Issues</a> •
   <a href="https://discord.gg/AsJ8krTT3N">Community</a>
 </p>
 
@@ -35,7 +35,7 @@ Cortex is the open-source brain for robots: vision, speech, language, tabular, a
 
 All other Linux distributions:
 ```bash
-curl -s https://raw.githubusercontent.com/janhq/cortex/main/engine/templates/linux/install.sh | sudo bash
+curl -s https://raw.githubusercontent.com/menloresearch/cortex/main/engine/templates/linux/install.sh | sudo bash
 ```
 
 ### Start the Server
@@ -144,7 +144,7 @@ cortex-nightly hardware activate
 - Quick troubleshooting: `cortex --help`
 - [Documentation](https://cortex.so/docs)
 - [Community Discord](https://discord.gg/FTk2MvZwJH)
-- [Report Issues](https://github.com/janhq/cortex.cpp/issues)
+- [Report Issues](https://github.com/menloresearch/cortex.cpp/issues)
 
 ---
 
@@ -182,6 +182,6 @@ The script to uninstall Cortex comes with the binary and was added to the `/usr/
 
 ## Contact Support
 
-- For support, please file a [GitHub ticket](https://github.com/janhq/cortex.cpp/issues/new/choose).
+- For support, please file a [GitHub ticket](https://github.com/menloresearch/cortex.cpp/issues/new/choose).
 - For questions, join our Discord [here](https://discord.gg/FTk2MvZwJH).
 - For long-form inquiries, please email [hello@jan.ai](mailto:hello@jan.ai).

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,7 +25,7 @@ docker pull menloltd/cortex:nightly-1.0.1-224
 - Build and Run Cortex Docker Container from Dockerfile
 
 ```bash
-git clone https://github.com/janhq/cortex.cpp.git
+git clone https://github.com/menloresearch/cortex.cpp.git
 cd cortex.cpp
 git submodule update --init
 

--- a/docker/download-cortex.llamacpp.sh
+++ b/docker/download-cortex.llamacpp.sh
@@ -4,7 +4,7 @@ VERSION=${1:-latest}
 
 # Get the latest version of the cortex.llamacpp
 if [ "$VERSION" = "latest" ]; then
-    VERSION=$(curl -s https://api.github.com/repos/janhq/cortex.llamacpp/releases/latest | jq -r '.tag_name' | sed 's/^v//');
+    VERSION=$(curl -s https://api.github.com/repos/menloresearch/cortex.llamacpp/releases/latest | jq -r '.tag_name' | sed 's/^v//');
 fi
 
 # Create the directory to store the cortex.llamacpp
@@ -13,18 +13,18 @@ cd /opt/cortex.llamacpp
 
 # Download the cortex.llamacpp engines
 echo -e "Downloading Cortex Llama version $VERSION"
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx-cuda-11-7.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx-cuda-12-0.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx2-cuda-11-7.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx2-cuda-12-0.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx2.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx512-cuda-11-7.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx512-cuda-12-0.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx512.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-noavx-cuda-11-7.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-noavx-cuda-12-0.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-noavx.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-vulkan.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cuda-11-7-linux-amd64.tar.gz
-wget https://github.com/janhq/cortex.llamacpp/releases/download/v$VERSION/cuda-12-0-linux-amd64.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx-cuda-11-7.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx-cuda-12-0.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx2-cuda-11-7.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx2-cuda-12-0.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx2.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx512-cuda-11-7.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx512-cuda-12-0.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-avx512.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-noavx-cuda-11-7.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-noavx-cuda-12-0.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-noavx.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cortex.llamacpp-$VERSION-linux-amd64-vulkan.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cuda-11-7-linux-amd64.tar.gz
+wget https://github.com/menloresearch/cortex.llamacpp/releases/download/v$VERSION/cuda-12-0-linux-amd64.tar.gz

--- a/docs/docs/basic-usage/cortex-js.md
+++ b/docs/docs/basic-usage/cortex-js.md
@@ -7,7 +7,7 @@ description: How to use the Cortex.js Library
 🚧 Cortex.js is currently under development, and this page is a stub for future development.
 :::
 
-[Cortex.js](https://github.com/janhq/cortex.js) is a Typescript client library that can be used to
+[Cortex.js](https://github.com/menloresearch/cortex.js) is a Typescript client library that can be used to
 interact with the Cortex API. It is a fork of the OpenAI Typescript library with additional methods for Local AI.
 
 This is still a work in progress, and we will let the community know once a stable version is available.
@@ -20,7 +20,7 @@ Cortex.cpp can be used in a Typescript application with the `cortex.js` library.
 ## Installation
 
 ```ts
-npm install @janhq/cortexso-node
+npm install @menloresearch/cortexso-node
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ npm install @janhq/cortexso-node
 
 ```diff
 - import OpenAI from 'openai';
-+ import Cortex from '@janhq/cortexso-node';
++ import Cortex from '@menloresearch/cortexso-node';
 ```
 
 2. Modify the initialization of the client to use Cortex.cpp:
@@ -46,7 +46,7 @@ npm install @janhq/cortexso-node
 ### Example Usage
 
 ```js
-import Cortex from "@janhq/cortexso-node";
+import Cortex from "@menloresearch/cortexso-node";
 
 async function inference() {
   const cortex = new Cortex({

--- a/docs/docs/basic-usage/cortex-py.md
+++ b/docs/docs/basic-usage/cortex-py.md
@@ -17,7 +17,7 @@ Cortex.cpp can be used in a Python application with the `cortex.py` library. Cor
 ## Installation
 
 ```py
-pip install @janhq/cortex-python
+pip install @menloresearch/cortex-python
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ pip install @janhq/cortex-python
 
 ```diff
 - from openai import OpenAI
-+ from @janhq/cortex-python import Cortex
++ from @menloresearch/cortex-python import Cortex
 ```
 
 2. Modify the initialization of the client to use Cortex.cpp:
@@ -40,7 +40,7 @@ pip install @janhq/cortex-python
 ### Example Usage
 
 ```py
-from @janhq/cortex-python import Cortex
+from @menloresearch/cortex-python import Cortex
 
 client = OpenAI(base_url="http://localhost:3928", api_key="cortex")
 

--- a/docs/docs/cortex-llamacpp.mdx
+++ b/docs/docs/cortex-llamacpp.mdx
@@ -77,7 +77,7 @@ The command will check, download, and install these dependencies:
   </TabItem>
 </Tabs>
 :::info
-To include `llamacpp` in your own server implementation, follow the steps [here](https://github.com/janhq/llamacpp/tree/main/examples/server).
+To include `llamacpp` in your own server implementation, follow the steps [here](https://github.com/menloresearch/llamacpp/tree/main/examples/server).
 :::
 
 #### Get GGUF Models
@@ -184,5 +184,5 @@ The future plans for `llamacpp` are focused on enhancing performance and expandi
 - **Multimodal Model Compatibility**: Expanding support to include a variety of multimodal models, enabling a broader range of applications and use cases.
 
 :::info
-To follow the latest developments of `llamacpp`, please see the [GitHub Repository](https://github.com/janhq/llamacpp).
+To follow the latest developments of `llamacpp`, please see the [GitHub Repository](https://github.com/menloresearch/llamacpp).
 :::

--- a/docs/docs/cortex-onnx.mdx
+++ b/docs/docs/cortex-onnx.mdx
@@ -40,7 +40,7 @@ The command will check, download, and install these dependencies for Windows:
    - vcruntime140_1.dll
 ```
 :::info
-To include `onnx` in your own server implementation, follow the steps [here](https://github.com/janhq/onnx/tree/main/examples/server).
+To include `onnx` in your own server implementation, follow the steps [here](https://github.com/menloresearch/onnx/tree/main/examples/server).
 :::
 
 #### Get ONNX Models

--- a/docs/docs/cortex-tensorrt-llm.mdx
+++ b/docs/docs/cortex-tensorrt-llm.mdx
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 ## Introduction
 
-[Cortex.tensorrt-llm](https://github.com/janhq/tensorrt-llm) is a C++ inference library for NVIDIA GPUs. It submodules NVIDIA’s [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) for GPU accelerated inference.
+[Cortex.tensorrt-llm](https://github.com/menloresearch/tensorrt-llm) is a C++ inference library for NVIDIA GPUs. It submodules NVIDIA’s [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) for GPU accelerated inference.
 
 In addition to TensorRT-LLM, `tensorrt-llm` adds: 
 
@@ -58,7 +58,7 @@ The command will check, download, and install these dependencies:
   </TabItem>
 </Tabs>
 :::info
-To include `tensorrt-llm` in your own server implementation, follow the steps [here](https://github.com/janhq/tensorrt-llm/tree/rel).
+To include `tensorrt-llm` in your own server implementation, follow the steps [here](https://github.com/menloresearch/tensorrt-llm/tree/rel).
 :::
 
 #### Get TensorRT-LLM Models

--- a/docs/docs/engines/engine-extension.mdx
+++ b/docs/docs/engines/engine-extension.mdx
@@ -163,7 +163,7 @@ Please ensure all dependencies are included with your dynamic library. This allo
 
 #### 4.1 Publishing Your Engine (Optional)
 
-If you wish to make your engine publicly available, you can publish it through GitHub. For reference, examine the [cortex.llamacpp releases](https://github.com/janhq/cortex.llamacpp/releases) structure:
+If you wish to make your engine publicly available, you can publish it through GitHub. For reference, examine the [cortex.llamacpp releases](https://github.com/menloresearch/cortex.llamacpp/releases) structure:
 
 - Each release tag should represent your version
 - Include all variants within the same release

--- a/docs/docs/engines/python-engine.mdx
+++ b/docs/docs/engines/python-engine.mdx
@@ -75,7 +75,7 @@ extra_params:
 
 ## Example: Ichigo Python Model
 
-[Ichigo python](https://github.com/janhq/ichigo) is a built-in Cortex model for chat with audio support.
+[Ichigo python](https://github.com/menloresearch/ichigo) is a built-in Cortex model for chat with audio support.
 
 ### Required Models
 
@@ -240,7 +240,7 @@ if __name__ == "__main__":
 
 1. Create model files following the example above
 2. Add required `requirements.txt` and `requirements.cuda.txt` files
-3. Trigger the [Python Script Package CI](https://github.com/janhq/cortex.cpp/actions/workflows/python-script-package.yml)
-4. Trigger the [Python Venv Package CI](https://github.com/janhq/cortex.cpp/actions/workflows/python-venv-package.yml)
+3. Trigger the [Python Script Package CI](https://github.com/menloresearch/cortex.cpp/actions/workflows/python-script-package.yml)
+4. Trigger the [Python Venv Package CI](https://github.com/menloresearch/cortex.cpp/actions/workflows/python-venv-package.yml)
 
 The CIs will build and publish your model to Hugging Face where it can then be downloaded and used.

--- a/docs/docs/guides/function-calling.md
+++ b/docs/docs/guides/function-calling.md
@@ -318,5 +318,5 @@ Use enums to improve function accuracy:
 - Function calling accuracy depends on model quality. Smaller models (8B-12B) work best with simple use cases.
 - Cortex.cpp implements function calling through prompt engineering, injecting system prompts when tools are specified.
 - Best compatibility with llama3.1 and derivatives (mistral-nemo, qwen)
-- System prompts can be customized for specific use cases (see [implementation details](https://github.com/janhq/cortex.cpp/pull/1472/files))
-- For complete implementation examples, refer to our [detailed guide](https://github.com/janhq/models/issues/16#issuecomment-2381129322)
+- System prompts can be customized for specific use cases (see [implementation details](https://github.com/menloresearch/cortex.cpp/pull/1472/files))
+- For complete implementation examples, refer to our [detailed guide](https://github.com/menloresearch/models/issues/16#issuecomment-2381129322)

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -32,7 +32,7 @@ For more information, please check out the [different channels](#different-chann
 | **Local**    | **Stable**  | **MacOS**        | [Download](https://app.cortexcpp.com/download/latest/mac-universal-local)                         |
 
 :::info
-For other versions, please look at [cortex.cpp repo](https://github.com/janhq/cortex.cpp) or each installer page.
+For other versions, please look at [cortex.cpp repo](https://github.com/menloresearch/cortex.cpp) or each installer page.
 :::
 
 

--- a/docs/docs/installation/docker.mdx
+++ b/docs/docs/installation/docker.mdx
@@ -59,7 +59,7 @@ docker pull menloltd/cortex:nightly-1.0.1-224
 
 1. **Clone the repo:**
 ```bash
-git clone https://github.com/janhq/cortex.cpp.git
+git clone https://github.com/menloresearch/cortex.cpp.git
 cd cortex.cpp
 git submodule update --init
 ```

--- a/docs/docs/installation/linux.mdx
+++ b/docs/docs/installation/linux.mdx
@@ -27,12 +27,12 @@ This instruction is for stable releases. For beta and nightly releases, please r
 
 - Network installer for all linux distros
    ```bash
-   curl -s https://raw.githubusercontent.com/janhq/cortex/main/engine/templates/linux/install.sh | sudo bash -s
+   curl -s https://raw.githubusercontent.com/menloresearch/cortex/main/engine/templates/linux/install.sh | sudo bash -s
    ```
 
 - Local installer for Debian-based distros
    ```bash
-   curl -s https://raw.githubusercontent.com/janhq/cortex/main/engine/templates/linux/install.sh | sudo bash -s -- --deb_local
+   curl -s https://raw.githubusercontent.com/menloresearch/cortex/main/engine/templates/linux/install.sh | sudo bash -s -- --deb_local
    ```
 
 - Parameters
@@ -83,7 +83,7 @@ sudo /usr/bin/cortex-uninstall.sh
 
 1. **Clone the Cortex Repository**
    ```bash
-   git clone https://github.com/janhq/cortex.cpp.git
+   git clone https://github.com/menloresearch/cortex.cpp.git
    cd cortex.cpp
    git submodule update --init
    ```

--- a/docs/docs/installation/mac.mdx
+++ b/docs/docs/installation/mac.mdx
@@ -13,7 +13,7 @@ The instructions below are for stable releases only. For beta and nightly releas
 :::
 
 1. Download the Linux installer:
-- From release: https://github.com/janhq/cortex.cpp/releases
+- From release: https://github.com/menloresearch/cortex.cpp/releases
 - From quick download links:
     - Local installer `.deb`:
         - Stable: https://app.cortexcpp.com/download/latest/mac-universal-local
@@ -80,7 +80,7 @@ The script requires sudo permission.
 
 1. **Clone the Cortex Repository**
    ```bash
-   git clone https://github.com/janhq/cortex.cpp.git
+   git clone https://github.com/menloresearch/cortex.cpp.git
    cd cortex.cpp
    git submodule update --init
    ```

--- a/docs/docs/installation/windows.mdx
+++ b/docs/docs/installation/windows.mdx
@@ -21,7 +21,7 @@ and `cortex-nightly`, respectively.
 :::
 
 Download the windows installer:
-- From release: https://github.com/janhq/cortex.cpp/releases
+- From release: https://github.com/menloresearch/cortex.cpp/releases
 - From quick download links:
     - Local installer `.deb`:
         - Stable: https://app.cortexcpp.com/download/latest/windows-amd64-local
@@ -77,7 +77,7 @@ Follow the [linux installation steps](linux) to install Cortex.cpp on the WSL.
 
 1. **Clone the Cortex Repository**
    ```cmd
-   git clone https://github.com/janhq/cortex.cpp.git
+   git clone https://github.com/menloresearch/cortex.cpp.git
    cd cortex.cpp
    git submodule update --init
    ```

--- a/docs/docs/overview.mdx
+++ b/docs/docs/overview.mdx
@@ -17,7 +17,7 @@ Key Features:
 - Full C++ implementation, packageable into Desktop and Mobile apps
 - Pull from Huggingface, or Cortex Built-in Model Library
 - Models stored in universal file formats (vs blobs)
-- Swappable Inference Backends (default: [`llamacpp`](https://github.com/janhq/cortex.llamacpp) and [`ONNXRuntime`](https://github.com/janhq/cortex.onnx))
+- Swappable Inference Backends (default: [`llamacpp`](https://github.com/menloresearch/cortex.llamacpp) and [`ONNXRuntime`](https://github.com/menloresearch/cortex.onnx))
 - Cortex can be deployed as a standalone API server, or integrated into apps like [Jan.ai](https://jan.ai/)
 - Automatic API docs for your server
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -214,7 +214,7 @@ const config: Config = {
         async contentLoaded({ content, actions }) {
           const { setGlobalData } = actions;
           const fetchRepoInfo = await fetch(
-            "https://api.github.com/repos/janhq/cortex.cpp"
+            "https://api.github.com/repos/menloresearch/cortex.cpp"
           );
           const repoInfo = await fetchRepoInfo.json();
           setGlobalData(repoInfo);
@@ -227,7 +227,7 @@ const config: Config = {
         async contentLoaded({ content, actions }) {
           const { setGlobalData } = actions;
           const fetchLatestRelease = await fetch(
-            "https://api.github.com/repos/janhq/cortex.cpp/releases/latest"
+            "https://api.github.com/repos/menloresearch/cortex.cpp/releases/latest"
           );
           const latestRelease = await fetchLatestRelease.json();
           setGlobalData(latestRelease);
@@ -310,7 +310,7 @@ const config: Config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "janhq", // Usually your GitHub org/user name.
+  organizationName: "menloresearch", // Usually your GitHub org/user name.
   projectName: "cortex", // Usually your repo name.
 
   onBrokenLinks: "throw",
@@ -342,7 +342,7 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/janhq/cortex.cpp/blob/dev/docs/",
+          editUrl: "https://github.com/menloresearch/cortex.cpp/blob/dev/docs/",
         },
         sitemap: {
           changefreq: "daily",
@@ -451,7 +451,7 @@ const config: Config = {
           items: [
             {
               label: "Github",
-              href: "https://github.com/janhq/cortex.cpp",
+              href: "https://github.com/menloresearch/cortex.cpp",
             },
             {
               label: "Discord",

--- a/docs/src/components/Announcement/index.tsx
+++ b/docs/src/components/Announcement/index.tsx
@@ -7,7 +7,7 @@ const Announcement = () => {
       <div className="flex items-center gap-2">
         <span>🎉</span>
         <p className="mb-0 text-neutral-100 font-medium">
-          <a href="https://github.com/janhq/cortex.cpp/releases/tag/v1.0.1" className="no-underline hover:no-underline">
+          <a href="https://github.com/menloresearch/cortex.cpp/releases/tag/v1.0.1" className="no-underline hover:no-underline">
             {" "}
             Cortex.cpp v1.0 is now live on GitHub. Check it out!
           </a>

--- a/docs/src/components/SocialNavbar/index.tsx
+++ b/docs/src/components/SocialNavbar/index.tsx
@@ -14,7 +14,7 @@ const SocialNavbar = () => {
     <div className="lg:flex hidden mr-4 items-center gap-x-2">
       <div className="header-github-link flex bg-neutral-100 dark:bg-neutral-800 rounded-lg py-1 px-2 items-center gap-2">
         <Link
-          to="https://github.com/janhq/cortex"
+          to="https://github.com/menloresearch/cortex"
           target="_blank"
           className="hover:no-underline text-black dark:text-white hover:text-inherit"
         >

--- a/docs/src/containers/Homepage/Download/CardDownload.tsx
+++ b/docs/src/containers/Homepage/Download/CardDownload.tsx
@@ -85,7 +85,7 @@ export default function CardDownload({ lastRelease }: Props) {
             .replace("{tag}", tag);
           return {
             ...system,
-            href: `https://github.com/janhq/cortex/releases/download/${lastRelease.tag_name}/${downloadUrl}`,
+            href: `https://github.com/menloresearch/cortex/releases/download/${lastRelease.tag_name}/${downloadUrl}`,
           };
         });
 

--- a/docs/static/huggingface/hub.json
+++ b/docs/static/huggingface/hub.json
@@ -11,7 +11,7 @@
     {
       "url": "https://huggingface.co/bartowski/Mistral-7B-Instruct-v0.3-GGUF/blob/main/Mistral-7B-Instruct-v0.3-Q4_K_M.gguf",
       "author": "Mistral AI",
-      "logo": "https://raw.githubusercontent.com/janhq/cortex-web/main/static/img/logos/mistral.svg",
+      "logo": "https://raw.githubusercontent.com/menloresearch/cortex-web/main/static/img/logos/mistral.svg",
       "model_name": "Mistral 7B Instruct v0.3 Q4_K_M GGUF",
       "note": "Small + Chat"
     },

--- a/docs/static/openapi/cortex.json
+++ b/docs/static/openapi/cortex.json
@@ -2830,7 +2830,7 @@
                       },
                       "url": {
                         "type": "string",
-                        "example": "https://api.github.com/repos/janhq/cortex.llamacpp/releases/186479804"
+                        "example": "https://api.github.com/repos/menloresearch/cortex.llamacpp/releases/186479804"
                       }
                     }
                   }
@@ -4918,13 +4918,13 @@
                 "audio"
               ]
             },
-            "description": "Specifies the modalities (types of input) supported by the model. Currently, cortex only support text modalities. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582).",
+            "description": "Specifies the modalities (types of input) supported by the model. Currently, cortex only support text modalities. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582).",
             "example": [
               "text"
             ]
           },
           "audio": {
-            "description": "Parameters for audio output. Required when audio output is requested with `modalities: ['audio']`. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582).",
+            "description": "Parameters for audio output. Required when audio output is requested with `modalities: ['audio']`. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582).",
             "type": "object",
             "properties": {
               "voice": {
@@ -4950,13 +4950,13 @@
           },
           "store": {
             "type": "boolean",
-            "description": "Whether or not to store the output of this chat completion request for use in our model distillation or evals products. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582).",
+            "description": "Whether or not to store the output of this chat completion request for use in our model distillation or evals products. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582).",
             "default": false,
             "example": false
           },
           "metadata": {
             "type": "object",
-            "description": "Developer-defined tags and values used for filtering completions in the dashboard. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582).",
+            "description": "Developer-defined tags and values used for filtering completions in the dashboard. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582).",
             "example": {
               "type": "conversation"
             }
@@ -4988,7 +4988,7 @@
           },
           "response_format": {
             "type": "object",
-            "description": "An object specifying the format that the model must output. Setting to { \"type\": \"json_object\" } enables JSON mode, which guarantees the message the model generates is valid JSON. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582).",
+            "description": "An object specifying the format that the model must output. Setting to { \"type\": \"json_object\" } enables JSON mode, which guarantees the message the model generates is valid JSON. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582).",
             "properties": {
               "type": {
                 "type": "string",
@@ -5012,7 +5012,7 @@
           },
           "service_tier": {
             "type": "string",
-            "description": "Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:\n\n - If set to 'auto', and the Project is Scale tier enabled, the system will utilize scale tier credits until they are exhausted.\n- If set to 'auto', and the Project is not Scale tier enabled, the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.\n- If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.\nWhen not set, the default behavior is 'auto'.\nWhen this parameter is set, the response body will include the service_tier utilized.\n\n We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582)."
+            "description": "Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:\n\n - If set to 'auto', and the Project is Scale tier enabled, the system will utilize scale tier credits until they are exhausted.\n- If set to 'auto', and the Project is not Scale tier enabled, the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.\n- If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.\nWhen not set, the default behavior is 'auto'.\nWhen this parameter is set, the response body will include the service_tier utilized.\n\n We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582)."
           },
           "stream_options": {
             "type": "object",
@@ -5094,7 +5094,7 @@
           },
           "user": {
             "type": "string",
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/janhq/cortex.cpp/issues/1582)."
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. We are actively working on this feature to bring cortex as fully OpenAI compatible platform. Planning and roadmap for this feature can be found [**here**](https://github.com/menloresearch/cortex.cpp/issues/1582)."
           },
           "dynatemp_range": {
             "type": "number",

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,11 +1,11 @@
 # cortex-cpp - Embeddable AI
 <p align="center">
-  <img alt="cortex-cpplogo" src="https://raw.githubusercontent.com/janhq/cortex/dev/assets/cortex-banner.png">
+  <img alt="cortex-cpplogo" src="https://raw.githubusercontent.com/menloresearch/cortex/dev/assets/cortex-banner.png">
 </p>
 
 <p align="center">
   <a href="https://jan.ai/cortex">Documentation</a> - <a href="https://jan.ai/api-reference">API Reference</a> 
-  - <a href="https://github.com/janhq/cortex/releases">Changelog</a> - <a href="https://github.com/janhq/cortex/issues">Bug reports</a> - <a href="https://discord.gg/AsJ8krTT3N">Discord</a>
+  - <a href="https://github.com/menloresearch/cortex/releases">Changelog</a> - <a href="https://github.com/menloresearch/cortex/issues">Bug reports</a> - <a href="https://discord.gg/AsJ8krTT3N">Discord</a>
 </p>
 
 > ⚠️ **cortex-cpp is currently in Development**: Expect breaking changes and bugs!
@@ -41,7 +41,7 @@ Ensure that your system meets the following requirements to run Cortex:
 
 ## Quickstart
 To install Cortex CLI, follow the steps below:
-1. Download cortex-cpp here: https://github.com/janhq/cortex/releases
+1. Download cortex-cpp here: https://github.com/menloresearch/cortex/releases
 2. Install cortex-cpp by running the downloaded file.
 
 3. Download a Model:
@@ -121,37 +121,37 @@ Below is the available list of the model parameters you can set when loading a m
   <tr>
     <td style="text-align:center"><b>Stable (Recommended)</b></td>
     <td style="text-align:center">
-      <a href='https://github.com/janhq/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2.tar.gz'>
         <img src='./docs/static/img/windows.png' style="height:15px; width: 15px" />
         <b>CPU</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/janhq/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2-cuda-12-0.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2-cuda-12-0.tar.gz'>
         <img src='./docs/static/img/windows.png' style="height:15px; width: 15px" />
         <b>CUDA</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/janhq/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-amd64.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-amd64.tar.gz'>
         <img src='./docs/static/img/mac.png' style="height:15px; width: 15px" />
         <b>Intel</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/janhq/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-arm64.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-arm64.tar.gz'>
         <img src='./docs/static/img/mac.png' style="height:15px; width: 15px" />
         <b>M1/M2</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/janhq/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-avx2.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-avx2.tar.gz'>
         <img src='./docs/static/img/linux.png' style="height:15px; width: 15px" />
         <b>CPU</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/janhq/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-cuda-12-0.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-cuda-12-0.tar.gz'>
         <img src='./docs/static/img/linux.png' style="height:15px; width: 15px" />
         <b>CUDA</b>
       </a>
@@ -159,7 +159,7 @@ Below is the available list of the model parameters you can set when loading a m
   </tr>
 </table>
 
-> Download the latest or older versions of Cortex-cpp at the **[GitHub Releases](https://github.com/janhq/cortex/releases)**.
+> Download the latest or older versions of Cortex-cpp at the **[GitHub Releases](https://github.com/menloresearch/cortex/releases)**.
 
 
 ## Manual Build
@@ -173,4 +173,4 @@ Manual build is a process in which the developers build the software manually. T
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=janhq/cortex.cpp&type=Date)](https://star-history.com/#janhq/cortex.cpp&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=menloresearch/cortex.cpp&type=Date)](https://star-history.com/#menloresearch/cortex.cpp&Date)

--- a/engine/cli/commands/cortex_upd_cmd.cc
+++ b/engine/cli/commands/cortex_upd_cmd.cc
@@ -515,10 +515,10 @@ bool CortexUpdCmd::GetLinuxInstallScript(const std::string& v,
                                          const std::string& channel) {
   std::vector<std::string> path_list;
   if (channel == "nightly") {
-    path_list = {"janhq",     "cortex.cpp", "dev",       "engine",
+    path_list = {"menloresearch",     "cortex.cpp", "dev",       "engine",
                  "templates", "linux",      "install.sh"};
   } else {
-    path_list = {"janhq",     "cortex.cpp", "main",      "engine",
+    path_list = {"menloresearch",     "cortex.cpp", "main",      "engine",
                  "templates", "linux",      "install.sh"};
   }
   auto url_obj = url_parser::Url{

--- a/engine/cli/commands/cortex_upd_cmd.h
+++ b/engine/cli/commands/cortex_upd_cmd.h
@@ -79,9 +79,9 @@ inline std::vector<std::string> GetReleasePath() {
   if (CORTEX_VARIANT == file_manager_utils::kNightlyVariant) {
     return {"cortex", "latest", "version.json"};
   } else if (CORTEX_VARIANT == file_manager_utils::kBetaVariant) {
-    return {"repos", "janhq", "cortex.cpp", "releases"};
+    return {"repos", "menloresearch", "cortex.cpp", "releases"};
   } else {
-    return {"repos", "janhq", "cortex.cpp", "releases", "latest"};
+    return {"repos", "menloresearch", "cortex.cpp", "releases", "latest"};
   }
 }
 

--- a/engine/cli/main.cc
+++ b/engine/cli/main.cc
@@ -154,7 +154,7 @@ int main(int argc, char* argv[]) {
       auto get_latest_version = []() -> cpp::result<std::string, std::string> {
         try {
           auto res = github_release_utils::GetReleaseByVersion(
-              "janhq", "cortex.llamacpp", "latest");
+              "menloresearch", "cortex.llamacpp", "latest");
           if (res.has_error()) {
             CTL_ERR("Failed to get latest llama.cpp version: " << res.error());
             return cpp::fail("Failed to get latest llama.cpp version: " +

--- a/engine/e2e-test/api/engines/test_api_engine_install_nightly.py
+++ b/engine/e2e-test/api/engines/test_api_engine_install_nightly.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 from utils.test_runner import start_server, stop_server, get_latest_pre_release_tag
 
-latest_pre_release_tag = get_latest_pre_release_tag("janhq", "cortex.llamacpp")
+latest_pre_release_tag = get_latest_pre_release_tag("menloresearch", "cortex.llamacpp")
 
 class TestApiEngineInstall:
 

--- a/engine/e2e-test/cli/engines/test_cli_engine_install_nightly.py
+++ b/engine/e2e-test/cli/engines/test_cli_engine_install_nightly.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 from utils.test_runner import run, start_server, stop_server, get_latest_pre_release_tag
 
-latest_pre_release_tag = get_latest_pre_release_tag("janhq", "cortex.llamacpp")
+latest_pre_release_tag = get_latest_pre_release_tag("menloresearch", "cortex.llamacpp")
 
 class TestCliEngineInstall:
     def setup_and_teardown(self):

--- a/engine/examples/example-docker/Dockerfile
+++ b/engine/examples/example-docker/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Install curl, unzip, and numactl, download the file, unzip it, then remove unnecessary packages
 RUN apt-get update && \
     apt-get install -y curl tar gzip numactl && \
-    curl -L "https://github.com/janhq/nitro/releases/download/v0.1.17/nitro-0.1.17-linux-amd64.tar.gz" -o nitro.tar.gz && \
+    curl -L "https://github.com/menloresearch/nitro/releases/download/v0.1.17/nitro-0.1.17-linux-amd64.tar.gz" -o nitro.tar.gz && \
     tar -xzvf nitro.tar.gz && \
     rm nitro.tar.gz && \
     apt-get remove --purge -y curl tar gzip && \

--- a/engine/examples/example-docker/alpine.Dockerfile
+++ b/engine/examples/example-docker/alpine.Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /work
 RUN apk add --no-cache git cmake g++ make util-linux-dev zlib-dev
 
 # Clone code
-RUN git clone --recurse-submodules -j2 --depth 1 --branch v${NITRO_VERSION} --single-branch https://github.com/janhq/nitro.git
+RUN git clone --recurse-submodules -j2 --depth 1 --branch v${NITRO_VERSION} --single-branch https://github.com/menloresearch/nitro.git
 
 # Build
 RUN cd nitro && \

--- a/engine/examples/example-docker/cuda.Dockerfile
+++ b/engine/examples/example-docker/cuda.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Install required packages
 RUN apt-get update && \
     apt-get install -y git cmake numactl uuid-dev && \
-    git clone --recurse https://github.com/janhq/nitro nitro && \
+    git clone --recurse https://github.com/menloresearch/nitro nitro && \
     cd nitro && \
     ./install_deps.sh && \
     mkdir build && \

--- a/engine/install.bat
+++ b/engine/install.bat
@@ -41,11 +41,11 @@ echo %VERSION%
 :: Get the release
 if "%VERSION%"=="latest" (
     :: If the version is set to "latest", get the latest version number from the cortex-cpp GitHub repository
-    for /f "delims=" %%i in ('powershell -Command "& {$version = Invoke-RestMethod -Uri 'https://api.github.com/repos/janhq/cortex/releases/latest'; return $version.tag_name.TrimStart('v')}"') do set "VERSION=%%i"
+    for /f "delims=" %%i in ('powershell -Command "& {$version = Invoke-RestMethod -Uri 'https://api.github.com/repos/menloresearch/cortex/releases/latest'; return $version.tag_name.TrimStart('v')}"') do set "VERSION=%%i"
 )
 
 :: Construct the download URL
-set "URL=https://github.com/janhq/cortex/releases/download/v%VERSION%/cortex-cpp-%VERSION%-win-amd64%AVX%"
+set "URL=https://github.com/menloresearch/cortex/releases/download/v%VERSION%/cortex-cpp-%VERSION%-win-amd64%AVX%"
 if "%GPU%"=="true" (
     :: If --gpu option is provided, append -cuda to the URL
     set "URL=%URL%-cuda"

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -139,7 +139,7 @@ fi
 
 # Construct GitHub API URL and get latest version if not specified
 if [ "$VERSION" == "latest" ]; then
-    API_URL="https://api.github.com/repos/janhq/cortex/releases/latest"
+    API_URL="https://api.github.com/repos/menloresearch/cortex/releases/latest"
     VERSION=$(curl -s $API_URL | jq -r ".tag_name" | sed 's/^v//')
 fi
 
@@ -167,7 +167,7 @@ case $OS in
         ;;
 esac
 
-DOWNLOAD_URL="https://github.com/janhq/cortex/releases/download/v${VERSION}/${FILE_NAME}"
+DOWNLOAD_URL="https://github.com/menloresearch/cortex/releases/download/v${VERSION}/${FILE_NAME}"
 
 # Check AVX support
 if [ -z "$AVX" ] && [ "$OS" == "Linux" ]; then

--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -443,7 +443,7 @@ std::string EngineService::GetMatchedVariant(
 cpp::result<std::vector<EngineService::EngineRelease>, std::string>
 EngineService::GetEngineReleases(const std::string& engine) const {
   auto ne = NormalizeEngine(engine);
-  return github_release_utils::GetReleases("janhq", ne);
+  return github_release_utils::GetReleases("menloresearch", ne);
 }
 
 cpp::result<std::vector<EngineService::EngineVariant>, std::string>
@@ -452,7 +452,7 @@ EngineService::GetEngineVariants(const std::string& engine,
                                  bool filter_compatible_only) const {
   auto ne = NormalizeEngine(engine);
   auto engine_release =
-      github_release_utils::GetReleaseByVersion("janhq", ne, version);
+      github_release_utils::GetReleaseByVersion("menloresearch", ne, version);
 
   if (engine_release.has_error()) {
     return cpp::fail("Failed to get engine release: " + engine_release.error());
@@ -891,7 +891,7 @@ std::vector<EngineV> EngineService::GetLoadedEngines() {
 cpp::result<github_release_utils::GitHubRelease, std::string>
 EngineService::GetLatestEngineVersion(const std::string& engine) const {
   auto ne = NormalizeEngine(engine);
-  auto res = github_release_utils::GetReleaseByVersion("janhq", ne, "latest");
+  auto res = github_release_utils::GetReleaseByVersion("menloresearch", ne, "latest");
   if (res.has_error()) {
     return cpp::fail("Failed to fetch engine " + engine + " latest version!");
   }

--- a/engine/templates/linux/install.sh
+++ b/engine/templates/linux/install.sh
@@ -50,10 +50,10 @@ get_latest_version() {
   local tag_name
   case $channel in
     stable)
-      tag_name=$(curl -s "https://api.github.com/repos/janhq/cortex.cpp/releases/latest" | grep -oP '"tag_name": "\K(.*)(?=")')
+      tag_name=$(curl -s "https://api.github.com/repos/menloresearch/cortex.cpp/releases/latest" | grep -oP '"tag_name": "\K(.*)(?=")')
       ;;
     beta)
-      tag_name=$(curl -s "https://api.github.com/repos/janhq/cortex.cpp/releases" | jq -r '.[] | select(.prerelease) | .tag_name' | head -n 1)
+      tag_name=$(curl -s "https://api.github.com/repos/menloresearch/cortex.cpp/releases" | jq -r '.[] | select(.prerelease) | .tag_name' | head -n 1)
       ;;
     nightly)
       tag_name=$(curl -s "https://delta.jan.ai/cortex/latest/version.json" | jq -r '.tag_name')
@@ -153,14 +153,14 @@ install_cortex() {
 
   case $channel in
     stable)
-      url_binary="https://github.com/janhq/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}.tar.gz"
-      url_deb_local="https://github.com/janhq/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-local-installer.deb"
-      url_deb_network="https://github.com/janhq/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-network-installer.deb"
+      url_binary="https://github.com/menloresearch/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}.tar.gz"
+      url_deb_local="https://github.com/menloresearch/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-local-installer.deb"
+      url_deb_network="https://github.com/menloresearch/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-network-installer.deb"
       ;;
     beta)
-      url_binary="https://github.com/janhq/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}.tar.gz"
-      url_deb_local="https://github.com/janhq/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-local-installer.deb"
-      url_deb_network="https://github.com/janhq/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-network-installer.deb"
+      url_binary="https://github.com/menloresearch/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}.tar.gz"
+      url_deb_local="https://github.com/menloresearch/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-local-installer.deb"
+      url_deb_network="https://github.com/menloresearch/cortex.cpp/releases/download/v${version}/cortex-${version}-linux-${ARCH}-network-installer.deb"
       ;;
     nightly)
       url_binary="https://delta.jan.ai/cortex/v${version}/linux-${ARCH}/cortex-nightly.tar.gz"

--- a/engine/test/components/test_github_release_utils.cc
+++ b/engine/test/components/test_github_release_utils.cc
@@ -6,14 +6,14 @@ class GitHubReleaseUtilsTest : public ::testing::Test {};
 TEST_F(GitHubReleaseUtilsTest, AbleToGetReleaseByVersion) {
   auto version{"v0.1.36"};
   auto result = github_release_utils::GetReleaseByVersion(
-      "janhq", "cortex.llamacpp", version);
+      "menloresearch", "cortex.llamacpp", version);
 
   ASSERT_TRUE(result.has_value());
   ASSERT_EQ(result->tag_name, version);
 }
 
 TEST_F(GitHubReleaseUtilsTest, AbleToGetReleaseList) {
-  auto result = github_release_utils::GetReleases("janhq", "cortex.llamacpp");
+  auto result = github_release_utils::GetReleases("menloresearch", "cortex.llamacpp");
 
   ASSERT_TRUE(result.has_value());
   ASSERT_TRUE(result->size() > 0);


### PR DESCRIPTION
This pull request includes changes to update repository references from `janhq` to `menloresearch` across multiple files. The most important changes focus on updating URLs and repository links for consistency.

Repository reference updates:

* [`.github/ISSUE_TEMPLATE/QA_checklist.md`](diffhunk://#diff-dcffaf201131d5396a8c9c198b3c83b9fd3ef587463c9129027d952dfe6bd2ecL73-R73): Updated the URL for configuring `cortex start` parameters.
* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L6-R6): Updated the URL for Cortex Discussions.
* [`.github/workflows/beta-build.yml`](diffhunk://#diff-f9ceabf8a977816576270d7b6a3dd5a2a49313df4a286539a0ed6efa584b8d70L148-R164): Updated URLs for various installer and binary downloads.
* [`.github/workflows/template-build-linux.yml`](diffhunk://#diff-9da4dbbf3227f76b08c4f4fdbb0400c14ca74ed6b10072a5511986f39fd6ffc9L172-R188): Updated URLs for downloading dependencies for Linux builds.
* [`BUILDING.md`](diffhunk://#diff-f1355fd54329147c830843ab133fed7716180c3242031487b861a2a3235d0078L3-R6): Updated repository clone URL and Codespaces link. [[1]](diffhunk://#diff-f1355fd54329147c830843ab133fed7716180c3242031487b861a2a3235d0078L3-R6) [[2]](diffhunk://#diff-f1355fd54329147c830843ab133fed7716180c3242031487b861a2a3235d0078L76-R76)