### PR TITLE
feat: allow to configure api_keys by cli

### DIFF
--- a/engine/cli/command_line_parser.cc
+++ b/engine/cli/command_line_parser.cc
@@ -437,7 +437,7 @@ void CommandLineParser::SetupConfigsCommands() {
 
     auto is_empty = true;
     for (const auto& [key, value] : config_update_opts_) {
-      if (!value.empty()) {
+      if (!value.empty() || key == "api_keys") {
         is_empty = false;
         break;
       }

--- a/engine/cli/commands/config_upd_cmd.cc
+++ b/engine/cli/commands/config_upd_cmd.cc
@@ -50,6 +50,7 @@ void commands::ConfigUpdCmd::Exec(
 
   auto non_null_opts = std::unordered_map<std::string, std::string>();
   for (const auto& [key, value] : options) {
+    // In case of api_keys, we allow empty value
     if (value.empty() && key != "api_keys") {
       continue;
     }

--- a/engine/common/api_server_configuration.h
+++ b/engine/common/api_server_configuration.h
@@ -97,6 +97,15 @@ static const std::unordered_map<std::string, ApiConfigurationMetadata>
                                   .accept_value = "string",
                                   .default_value = "",
                                   .allow_empty = true}},
+        {"api_keys",
+         ApiConfigurationMetadata{
+             .name = "api_keys",
+             .desc = "API header key to get access to server APIs",
+             .group = "Token",
+             .accept_value = "comma separated",
+             .default_value = "",
+             .allow_empty = true}},
+
 };
 
 class ApiServerConfiguration {

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -257,7 +257,7 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
 
     if (req->getHeader("Authorization").empty() &&
         req->path() == "/v1/configs") {
-      CTL_WRN("Require API key to acceess /v1/configs");
+      CTL_WRN("Require API key to access /v1/configs");
       return false;
     }
     

--- a/engine/main.cc
+++ b/engine/main.cc
@@ -255,6 +255,12 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
     static const std::unordered_set<std::string> public_endpoints = {
         "/openapi.json", "/healthz", "/processManager/destroy"};
 
+    if (req->getHeader("Authorization").empty() &&
+        req->path() == "/v1/configs") {
+      CTL_WRN("Require API key to acceess /v1/configs");
+      return false;
+    }
+    
     // If API key is not set, skip validation
     if (api_keys.empty()) {
       return true;


### PR DESCRIPTION
## Describe Your Changes

- Allow to configure api_keys via CLI, in case of `api_keys` we don't start server like other parameters
- /v1/configs requires api_key header to access
- Syntax:  `cortex config --api_keys "api_key1, api_key2"
- To support Jan use-case

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed