### PR TITLE
fix: prevent unlimited loop due to invalid filename in path

### DIFF
--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -22,6 +22,9 @@ std::filesystem::path SanitizePath(const std::filesystem::path& user_input,
     if (std::filesystem::equivalent(p, abs_base)) {
       return resolved_path;
     }
+    if (p == p.parent_path()) {  // reached the root directory
+      break;
+    }
   }
   return {};
 }


### PR DESCRIPTION
## Describe Your Changes

- This PR addresses an infinite loop issue in the SanitizePath function. The bug occurs when the user-supplied filename (e.g., ../hi) results in a resolved path that is outside of the base directory. When the resolved path reaches the root directory, the loop fails to exit because the root is its own parent, causing the loop to iterate indefinitely.

## Fixes Issues

- Closes #2153 

## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed