### PR TITLE
feat: add option to start server with --api_keys

### DIFF
--- a/engine/main.cc
+++ b/engine/main.cc
@@ -260,7 +260,7 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
       CTL_WRN("Require API key to access /v1/configs");
       return false;
     }
-    
+
     // If API key is not set, skip validation
     if (api_keys.empty()) {
       return true;
@@ -383,6 +383,7 @@ void print_help() {
                "~/cortexcpp)\n";
   std::cout << "  --host                  Host name (default: 127.0.0.1)\n";
   std::cout << "  --port                  Port number (default: 39281)\n";
+  std::cout << "  --api_configs           Keys to acess API endpoints\n";
   std::cout << "  --ignore_cout           Ignore cout output\n";
   std::cout << "  --loglevel              Set log level\n";
 
@@ -411,6 +412,7 @@ int main(int argc, char* argv[]) {
 
   std::optional<std::string> server_host;
   std::optional<int> server_port;
+  std::optional<std::string> api_keys;
   bool ignore_cout_log = false;
 #if defined(_WIN32)
   for (int i = 0; i < argc; i++) {
@@ -427,6 +429,8 @@ int main(int argc, char* argv[]) {
       server_host = cortex::wc::WstringToUtf8(argv[i + 1]);
     } else if (command == L"--port") {
       server_port = std::stoi(argv[i + 1]);
+    } else if (command == L"--api_keys") {
+      api_keys = cortex::wc::WstringToUtf8(argv[i + 1]);
     } else if (command == L"--ignore_cout") {
       ignore_cout_log = true;
     } else if (command == L"--loglevel") {
@@ -447,6 +451,8 @@ int main(int argc, char* argv[]) {
       server_host = argv[i + 1];
     } else if (strcmp(argv[i], "--port") == 0) {
       server_port = std::stoi(argv[i + 1]);
+    } else if (strcmp(argv[i], "--api_keys") == 0) {
+      api_keys = argv[i + 1];
     } else if (strcmp(argv[i], "--ignore_cout") == 0) {
       ignore_cout_log = true;
     } else if (strcmp(argv[i], "--loglevel") == 0) {
@@ -479,6 +485,15 @@ int main(int argc, char* argv[]) {
           CTL_ERR("Error update " << config_path.string() << result.error());
         }
       }
+    }
+  }
+
+  if (api_keys) {
+    auto config = file_manager_utils::GetCortexConfig();
+    config.apiKeys = string_utils::SplitBy(*api_keys, ",");
+    auto result = file_manager_utils::UpdateCortexConfig(config);
+    if (result.has_error()) {
+      CTL_ERR(result.error());
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes updates to the `engine/main.cc` file to add support for API keys configuration. The changes introduce a new command-line argument for specifying API keys and handle the configuration update accordingly.

Key changes:

* Added a new command-line argument `--api_keys` to specify API keys in the `print_help` function.
* Introduced a new optional variable `api_keys` in the `main` function to store the API keys.
* Updated the command-line argument parsing logic to handle the `--api_keys` argument for both wide and narrow character strings. [[1]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R432-R433) [[2]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5R454-R455)
* Added logic to update the Cortex configuration with the provided API keys if the `--api_keys` argument is specified.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed