### PR TITLE
fix: set /events as a public endpoint

### DIFF
--- a/engine/main.cc
+++ b/engine/main.cc
@@ -253,7 +253,7 @@ void RunServer(std::optional<std::string> host, std::optional<int> port,
   auto validate_api_key = [config_service](const drogon::HttpRequestPtr& req) {
     auto api_keys = config_service->GetApiServerConfiguration()->api_keys;
     static const std::unordered_set<std::string> public_endpoints = {
-        "/openapi.json", "/healthz", "/processManager/destroy"};
+        "/openapi.json", "/healthz", "/processManager/destroy", "/events"};
 
     if (req->getHeader("Authorization").empty() &&
         req->path() == "/v1/configs") {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `engine/main.cc` file. The change adds a new endpoint, `/events`, to the list of public endpoints that do not require API key validation.

* [`engine/main.cc`](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L256-R256): Added `/events` to the `public_endpoints` set.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed