### PR TITLE
ci: add cortex docs new release

### DIFF
--- a/.github/workflows/cortex-docs-new-release.yml
+++ b/.github/workflows/cortex-docs-new-release.yml
@@ -6,9 +6,6 @@ on:
       - published
       - edited
       - released
-  pull_request:
-    branches:
-        - dev
 
 jobs:
   deploy:

--- a/.github/workflows/cortex-docs-new-release.yml
+++ b/.github/workflows/cortex-docs-new-release.yml
@@ -1,0 +1,64 @@
+name: Deploy Docs on new release
+
+on:
+  release:
+    types:
+      - published
+      - edited
+      - released
+
+jobs:
+  deploy:
+    name: Deploy to CloudFlare Pages
+    env:
+      CLOUDFLARE_PROJECT_NAME: cortex-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install jq      
+        uses: dcarbone/install-jq-action@v2.0.1
+
+      - name: Fill env vars
+        working-directory: docs
+        continue-on-error: true
+        run: |
+          env_example_file=".env.example"
+          touch .env
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == *"="* ]]; then
+              var_name=$(echo $line | cut -d '=' -f 1)
+              echo $var_name
+              var_value="$(jq -r --arg key "$var_name" '.[$key]' <<< "$SECRETS")"
+              echo "$var_name=$var_value" >> .env
+            fi
+          done < "$env_example_file"
+        env:
+          SECRETS: '${{ toJson(secrets) }}'
+
+      - name: Install dependencies
+        working-directory: docs
+        run: yarn install
+      - name: Build website
+        working-directory: docs
+        run: export NODE_ENV=production && yarn build && cp _redirects build/_redirects
+
+      - name: Publish to Cloudflare Pages Production
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
+          directory: ./docs/build
+          branch: main
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cortex-docs-new-release.yml
+++ b/.github/workflows/cortex-docs-new-release.yml
@@ -53,8 +53,13 @@ jobs:
         run: yarn install
       - name: Build website
         working-directory: docs
-        run: export NODE_ENV=production && yarn build && cp _redirects build/_redirects
+        run: export NODE_ENV=production && yarn build
 
+      - name: Copy redirect file
+        working-directory: docs
+        continue-on-error: true
+        run: cp _redirects build/_redirects
+  
       - name: Publish to Cloudflare Pages Production
         uses: cloudflare/pages-action@v1
         with:

--- a/.github/workflows/cortex-docs-new-release.yml
+++ b/.github/workflows/cortex-docs-new-release.yml
@@ -6,6 +6,9 @@ on:
       - published
       - edited
       - released
+  pull_request:
+    branches:
+        - dev
 
 jobs:
   deploy:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of documentation upon the release of new versions. The workflow is configured to trigger on various release events and deploy the documentation to Cloudflare Pages. 

Key changes include:

* **New GitHub Actions Workflow**:
  * [`.github/workflows/cortex-docs-new-release.yml`](diffhunk://#diff-727510b200c5fba511c1c750fc0428a489d7a10bbd07e0432d1c7009b87979a3R1-R64): Added a new workflow named `Deploy Docs on new release` that triggers on release events (published, edited, released) and deploys the documentation to Cloudflare Pages.