### PR TITLE
fix: add cors and allowed_origins to server standalone parameters

### DIFF
--- a/engine/utils/string_utils.h
+++ b/engine/utils/string_utils.h
@@ -228,4 +228,5 @@ inline bool AreUrlPathsEqual(const std::string& path1,
 
   return true;
 }
+
 }  // namespace string_utils


### PR DESCRIPTION
## Describe Your Changes

This pull request refactors the server setup and configuration process in the `engine/main.cc` file by introducing a `ServerParams` struct and a `SetupServer` function. Additionally, it updates command-line argument handling and help text to reflect these changes.

Key changes include:

### Refactoring server setup:

* Introduced the `ServerParams` struct to encapsulate server parameters such as `server_host`, `server_port`, `api_keys`, `cors`, and `allowed_origins`. (`[engine/main.ccL63-R102](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L63-R102)`)
* Added the `SetupServer` function to handle server configuration updates based on the `ServerParams` struct. (`[engine/main.ccL63-R102](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L63-R102)`)
* Modified the `RunServer` function to no longer accept `host` and `port` parameters, as these are now handled by `SetupServer`. (`[[1]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L84-L100)`, `[[2]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L571-R600)`)

### Updating command-line argument handling:

* Updated command-line argument parsing to populate the `ServerParams` struct instead of individual variables. (`[[1]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L464-R486)`, `[[2]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L480-R512)`, `[[3]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L502-R542)`)
* Added support for new command-line arguments `--cors` and `--allowed_origins`. (`[[1]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L480-R512)`, `[[2]](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L502-R542)`)

### Improving help text:

* Updated the help text to include the new `--cors` argument and renamed `--api_configs` to `--api_keys`. (`[engine/main.ccL437-R459](diffhunk://#diff-8651ef9f256f38a44086c44bf92b235f3486b0b555bb4c56632e9a54d01f40c5L437-R459)`)

### Minor changes:

* Added a missing newline at the end of the `AreUrlPathsEqual` function in `engine/utils/string_utils.h`. (`[engine/utils/string_utils.hR231](diffhunk://#diff-7b4479b6eba1e98453848526c53fda755811ed5017fa743307d6ed174a0ee580R231)`)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed