### PR TITLE
chore: enable create file test for all platforms

### DIFF
--- a/engine/e2e-test/api/files/test_api_create_file.py
+++ b/engine/e2e-test/api/files/test_api_create_file.py
@@ -23,7 +23,6 @@ class TestApiCreateFile:
         # Teardown
         stop_server()
         
-    @pytest.mark.skipif(platform.system() != "Linux", reason="Todo: fix later on Mac and Window")
     def test_api_create_file_successfully(self):
         # Define file path
         file_path_rel = os.path.join("e2e-test", "api", "files", "blank.txt")


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `engine/e2e-test/api/files/test_api_create_file.py` file. The change involves removing a `pytest.mark.skipif` decorator from the `test_api_create_file_successfully` method, which previously skipped the test on non-Linux platforms.

Testing improvements:

* [`engine/e2e-test/api/files/test_api_create_file.py`](diffhunk://#diff-5e9b78dcd61435c3602bf5903add2a7bd265b4a737f11afc2c357d2b3a5b1eeeL26): Removed the `pytest.mark.skipif` decorator that skipped the `test_api_create_file_successfully` test on non-Linux platforms, indicating an intention to fix the test for Mac and Windows platforms in the future.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed