### PR TITLE
fix: std::filesystem::equivalent does not work for non-exist path

### DIFF
--- a/engine/e2e-test/api/files/test_api_create_file.py
+++ b/engine/e2e-test/api/files/test_api_create_file.py
@@ -23,7 +23,6 @@ class TestApiCreateFile:
         # Teardown
         stop_server()
         
-    @pytest.mark.skipif(platform.system() != "Linux", reason="Todo: fix later on Mac and Window")
     def test_api_create_file_successfully(self):
         # Define file path
         file_path_rel = os.path.join("e2e-test", "api", "files", "blank.txt")

--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -18,14 +18,10 @@ std::filesystem::path SanitizePath(const std::filesystem::path& user_input,
   std::filesystem::path resolved_path = std::filesystem::weakly_canonical(
       std::filesystem::path(basedir) / std::filesystem::path(user_input));
   /* Ensure the resolved path is within our basedir */
-  for (auto p = resolved_path; !p.empty(); p = p.parent_path()) {
-    if (std::filesystem::equivalent(p, abs_base)) {
-      return resolved_path;
-    }
-    if (p == p.parent_path()) {  // reached the root directory
-      break;
-    }
+  if (resolved_path.string().find(abs_base.string()) != std::string::npos) {
+    return resolved_path;
   }
+
   return {};
 }
 


### PR DESCRIPTION
* fix: std::filesystem::equivalent does not work for non-exist path

* chore: enable create file test for all platforms (#2183)

---------

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed